### PR TITLE
feat(ingestion): implement Pull-A-Part and upullitne TAP connectors

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -173,7 +173,7 @@ export const vehicle = sqliteTable(
   "vehicle",
   {
     vin: text("vin").primaryKey(),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne"
     year: integer("year").notNull(),
     make: text("make").notNull(),
     model: text("model").notNull(),
@@ -216,7 +216,7 @@ export const vehicle = sqliteTable(
 
 export const ingestionRun = sqliteTable("ingestion_run", {
   id: text("id").primaryKey(),
-  source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "all"
+  source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne" | "all"
   status: text("status").notNull(), // "running" | "success" | "error"
   vehiclesUpserted: integer("vehicles_upserted").default(0),
   vehiclesDeleted: integer("vehicles_deleted").default(0),
@@ -232,7 +232,7 @@ export const ingestionSourceRun = sqliteTable(
     runId: text("run_id")
       .notNull()
       .references(() => ingestionRun.id, { onDelete: "cascade" }),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne"
     status: text("status").notNull(), // "running" | "success" | "error" | "partial"
     startCursor: text("start_cursor"),
     nextCursor: text("next_cursor"),
@@ -255,7 +255,7 @@ export const vehicleSnapshot = sqliteTable(
     runId: text("run_id")
       .notNull()
       .references(() => ingestionRun.id, { onDelete: "cascade" }),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne"
     vin: text("vin").notNull(),
     year: integer("year").notNull(),
     make: text("make").notNull(),

--- a/schema.ts
+++ b/schema.ts
@@ -173,7 +173,7 @@ export const vehicle = sqliteTable(
   "vehicle",
   {
     vin: text("vin").primaryKey(),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
     year: integer("year").notNull(),
     make: text("make").notNull(),
     model: text("model").notNull(),
@@ -216,7 +216,7 @@ export const vehicle = sqliteTable(
 
 export const ingestionRun = sqliteTable("ingestion_run", {
   id: text("id").primaryKey(),
-  source: text("source").notNull(), // "pyp" | "row52" | "all"
+  source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart" | "all"
   status: text("status").notNull(), // "running" | "success" | "error"
   vehiclesUpserted: integer("vehicles_upserted").default(0),
   vehiclesDeleted: integer("vehicles_deleted").default(0),
@@ -232,7 +232,7 @@ export const ingestionSourceRun = sqliteTable(
     runId: text("run_id")
       .notNull()
       .references(() => ingestionRun.id, { onDelete: "cascade" }),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
     status: text("status").notNull(), // "running" | "success" | "error" | "partial"
     startCursor: text("start_cursor"),
     nextCursor: text("next_cursor"),
@@ -255,7 +255,7 @@ export const vehicleSnapshot = sqliteTable(
     runId: text("run_id")
       .notNull()
       .references(() => ingestionRun.id, { onDelete: "cascade" }),
-    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler"
+    source: text("source").notNull(), // "pyp" | "row52" | "autorecycler" | "pullapart"
     vin: text("vin").notNull(),
     year: integer("year").notNull(),
     make: text("make").notNull(),

--- a/scripts/run-ingestion.ts
+++ b/scripts/run-ingestion.ts
@@ -32,6 +32,7 @@ try {
   console.log("\n=== INGESTION COMPLETE ===");
   console.log(`PYP vehicles: ${result.pypCount}`);
   console.log(`Pull-A-Part vehicles: ${result.pullapartCount}`);
+  console.log(`U Pull-It Nebraska vehicles: ${result.upullitneCount}`);
   console.log(`Row52 vehicles: ${result.row52Count}`);
   console.log(`AutoRecycler vehicles: ${result.autorecyclerCount}`);
   console.log(`Total upserted: ${result.totalUpserted}`);

--- a/scripts/run-ingestion.ts
+++ b/scripts/run-ingestion.ts
@@ -31,6 +31,7 @@ try {
   const result = await runIngestion();
   console.log("\n=== INGESTION COMPLETE ===");
   console.log(`PYP vehicles: ${result.pypCount}`);
+  console.log(`Pull-A-Part vehicles: ${result.pullapartCount}`);
   console.log(`Row52 vehicles: ${result.row52Count}`);
   console.log(`AutoRecycler vehicles: ${result.autorecyclerCount}`);
   console.log(`Total upserted: ${result.totalUpserted}`);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     template: "%s | Junkyard Index",
   },
   description:
-    "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Row52, and more. Save searches and get email alerts when new vehicles arrive.",
+    "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more. Save searches and get email alerts when new vehicles arrive.",
   keywords: [
     "junkyard",
     "salvage yard",
@@ -41,13 +41,13 @@ export const metadata: Metadata = {
     siteName: "Junkyard Index",
     title: "Junkyard Index - Search Salvage Yard Inventory Nationwide",
     description:
-      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Row52, and more.",
+      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more.",
   },
   twitter: {
     card: "summary_large_image",
     title: "Junkyard Index - Search Salvage Yard Inventory Nationwide",
     description:
-      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Row52, and more.",
+      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more.",
   },
   robots: {
     index: true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     template: "%s | Junkyard Index",
   },
   description:
-    "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more. Save searches and get email alerts when new vehicles arrive.",
+    "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, U Pull-It Nebraska, Row52, and more. Save searches and get email alerts when new vehicles arrive.",
   keywords: [
     "junkyard",
     "salvage yard",
@@ -41,13 +41,13 @@ export const metadata: Metadata = {
     siteName: "Junkyard Index",
     title: "Junkyard Index - Search Salvage Yard Inventory Nationwide",
     description:
-      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more.",
+      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, U Pull-It Nebraska, Row52, and more.",
   },
   twitter: {
     card: "summary_large_image",
     title: "Junkyard Index - Search Salvage Yard Inventory Nationwide",
     description:
-      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, Row52, and more.",
+      "Search salvage yard inventory across the nation. Find used auto parts from LKQ Pick Your Part, Pull-A-Part, U Pull-It Nebraska, Row52, and more.",
   },
   robots: {
     index: true,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,7 @@ export default async function Home() {
       <section className="border-t px-4 py-24 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="mb-4 text-2xl font-semibold tracking-tight text-balance sm:text-3xl">
-            Four networks. One search.
+            Five networks. One search.
           </h2>
           <p className="text-muted-foreground mx-auto mb-12 max-w-xl text-pretty">
             We pull inventory from each source daily and combine it into a
@@ -165,6 +165,7 @@ export default async function Home() {
             {[
               "LKQ Pick Your Part",
               "Pull-A-Part / U-Pull-&-Pay",
+              "U Pull-It Nebraska",
               "Row52",
               "AutoRecycler",
             ].map((name) => (
@@ -186,7 +187,7 @@ export default async function Home() {
               value={formatYardBadgeCount(liveStats.yardCount)}
               label="Yards Nationwide"
             />
-            <StatCard value="4" label="Yard Networks" />
+            <StatCard value="5" label="Yard Networks" />
           </div>
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,7 @@ export default async function Home() {
       <section className="border-t px-4 py-24 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="mb-4 text-2xl font-semibold tracking-tight text-balance sm:text-3xl">
-            Three networks. One search.
+            Four networks. One search.
           </h2>
           <p className="text-muted-foreground mx-auto mb-12 max-w-xl text-pretty">
             We pull inventory from each source daily and combine it into a
@@ -162,7 +162,12 @@ export default async function Home() {
           </p>
 
           <div className="mb-16 flex flex-wrap items-center justify-center gap-x-10 gap-y-4">
-            {["LKQ Pick Your Part", "Row52", "AutoRecycler"].map((name) => (
+            {[
+              "LKQ Pick Your Part",
+              "Pull-A-Part / U-Pull-&-Pay",
+              "Row52",
+              "AutoRecycler",
+            ].map((name) => (
               <div key={name} className="flex items-center gap-2.5">
                 <div className="bg-muted flex size-8 items-center justify-center rounded-md">
                   <Car className="text-muted-foreground size-4" />
@@ -181,7 +186,7 @@ export default async function Home() {
               value={formatYardBadgeCount(liveStats.yardCount)}
               label="Yards Nationwide"
             />
-            <StatCard value="3" label="Yard Networks" />
+            <StatCard value="4" label="Yard Networks" />
           </div>
         </div>
       </section>

--- a/src/components/search/SaveSearchDialog.tsx
+++ b/src/components/search/SaveSearchDialog.tsx
@@ -228,11 +228,17 @@ export function SaveSearchDialog({
     const normalizedSources = (filters.sources ?? []).filter(
       (
         source,
-      ): source is "pyp" | "row52" | "autorecycler" | "pullapart" =>
+      ): source is
+        | "pyp"
+        | "row52"
+        | "autorecycler"
+        | "pullapart"
+        | "upullitne" =>
         source === "pyp" ||
         source === "row52" ||
         source === "autorecycler" ||
-        source === "pullapart",
+        source === "pullapart" ||
+        source === "upullitne",
     );
     const restFilters = {
       makes: filters.makes,

--- a/src/components/search/SaveSearchDialog.tsx
+++ b/src/components/search/SaveSearchDialog.tsx
@@ -226,10 +226,13 @@ export function SaveSearchDialog({
     const enableDiscord =
       notificationsEnabled && discordEnabled && !!hasDiscordSetup;
     const normalizedSources = (filters.sources ?? []).filter(
-      (source): source is "pyp" | "row52" | "autorecycler" =>
+      (
+        source,
+      ): source is "pyp" | "row52" | "autorecycler" | "pullapart" =>
         source === "pyp" ||
         source === "row52" ||
-        source === "autorecycler",
+        source === "autorecycler" ||
+        source === "pullapart",
     );
     const restFilters = {
       makes: filters.makes,

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -101,7 +101,12 @@ const KEY_TO_INDEX = Object.fromEntries(
   SORT_OPTIONS.map((o) => [o.key, o.indexName]),
 );
 const KNOWN_SORT_INDICES = new Set(SORT_OPTIONS.map((o) => o.indexName));
-const ALLOWED_SOURCES: DataSource[] = ["pyp", "row52", "autorecycler"];
+const ALLOWED_SOURCES: DataSource[] = [
+  "pyp",
+  "row52",
+  "autorecycler",
+  "pullapart",
+];
 
 function clampRouteYear(
   value: number | null,

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -106,6 +106,7 @@ const ALLOWED_SOURCES: DataSource[] = [
   "row52",
   "autorecycler",
   "pullapart",
+  "upullitne",
 ];
 
 function clampRouteYear(

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -18,6 +18,7 @@ interface FilterOptions {
 
 const SOURCE_LABELS: Record<DataSource, string> = {
   pyp: "Pick Your Part (PYP)",
+  pullapart: "Pull-A-Part / U-Pull-&-Pay",
   row52: "Row52 / Pick-n-Pull",
   autorecycler: "AutoRecycler.io",
 };
@@ -58,7 +59,12 @@ export function SidebarContent({
   onYearRangeChange,
   yearRangeLimits,
 }: SidebarContentProps) {
-  const availableSources: DataSource[] = ["pyp", "row52", "autorecycler"];
+  const availableSources: DataSource[] = [
+    "pyp",
+    "pullapart",
+    "row52",
+    "autorecycler",
+  ];
 
   return (
     <div className="space-y-6">

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -19,6 +19,7 @@ interface FilterOptions {
 const SOURCE_LABELS: Record<DataSource, string> = {
   pyp: "Pick Your Part (PYP)",
   pullapart: "Pull-A-Part / U-Pull-&-Pay",
+  upullitne: "U Pull-It Nebraska",
   row52: "Row52 / Pick-n-Pull",
   autorecycler: "AutoRecycler.io",
 };
@@ -62,6 +63,7 @@ export function SidebarContent({
   const availableSources: DataSource[] = [
     "pyp",
     "pullapart",
+    "upullitne",
     "row52",
     "autorecycler",
   ];

--- a/src/lib/__tests__/algolia-alert-search.test.ts
+++ b/src/lib/__tests__/algolia-alert-search.test.ts
@@ -24,7 +24,14 @@ describe("algolia alert search helpers", () => {
       {
         makes: ["Honda", "Toyota"],
         states: ["California", "Nevada"],
-        sources: ["pyp", "row52", "autorecycler", "pullapart", "ignore-me"],
+        sources: [
+          "pyp",
+          "row52",
+          "autorecycler",
+          "pullapart",
+          "upullitne",
+          "ignore-me",
+        ],
       },
       null,
     );
@@ -32,7 +39,7 @@ describe("algolia alert search helpers", () => {
     expect(filters).toContain('(make:"Honda" OR make:"Toyota")');
     expect(filters).toContain('(state:"California" OR state:"Nevada")');
     expect(filters).toContain(
-      '(source:"pyp" OR source:"row52" OR source:"autorecycler" OR source:"pullapart")',
+      '(source:"pyp" OR source:"row52" OR source:"autorecycler" OR source:"pullapart" OR source:"upullitne")',
     );
     expect(filters).not.toContain("ignore-me");
   });

--- a/src/lib/__tests__/algolia-alert-search.test.ts
+++ b/src/lib/__tests__/algolia-alert-search.test.ts
@@ -24,7 +24,7 @@ describe("algolia alert search helpers", () => {
       {
         makes: ["Honda", "Toyota"],
         states: ["California", "Nevada"],
-        sources: ["pyp", "row52", "autorecycler", "ignore-me"],
+        sources: ["pyp", "row52", "autorecycler", "pullapart", "ignore-me"],
       },
       null,
     );
@@ -32,7 +32,7 @@ describe("algolia alert search helpers", () => {
     expect(filters).toContain('(make:"Honda" OR make:"Toyota")');
     expect(filters).toContain('(state:"California" OR state:"Nevada")');
     expect(filters).toContain(
-      '(source:"pyp" OR source:"row52" OR source:"autorecycler")',
+      '(source:"pyp" OR source:"row52" OR source:"autorecycler" OR source:"pullapart")',
     );
     expect(filters).not.toContain("ignore-me");
   });

--- a/src/lib/__tests__/saved-search-filters.test.ts
+++ b/src/lib/__tests__/saved-search-filters.test.ts
@@ -33,7 +33,7 @@ describe("saved search filters schema", () => {
     const result = filtersSchema.safeParse({
       minYear: 2012,
       maxYear: nextYear,
-      sources: ["pyp", "row52"],
+      sources: ["pyp", "row52", "pullapart"],
     });
 
     expect(result.success).toBe(true);

--- a/src/lib/__tests__/saved-search-filters.test.ts
+++ b/src/lib/__tests__/saved-search-filters.test.ts
@@ -33,7 +33,7 @@ describe("saved search filters schema", () => {
     const result = filtersSchema.safeParse({
       minYear: 2012,
       maxYear: nextYear,
-      sources: ["pyp", "row52", "pullapart"],
+      sources: ["pyp", "row52", "pullapart", "upullitne"],
     });
 
     expect(result.success).toBe(true);

--- a/src/lib/algolia-alert-search.ts
+++ b/src/lib/algolia-alert-search.ts
@@ -66,7 +66,11 @@ export function buildAlertFiltersString(
   const sourcesClause = buildStringOrFilter(
     "source",
     (filters.sources ?? []).filter(
-      (s) => s === "pyp" || s === "row52" || s === "autorecycler",
+      (s) =>
+        s === "pyp" ||
+        s === "row52" ||
+        s === "autorecycler" ||
+        s === "pullapart",
     ),
   );
   if (sourcesClause) clauses.push(sourcesClause);

--- a/src/lib/algolia-alert-search.ts
+++ b/src/lib/algolia-alert-search.ts
@@ -70,7 +70,8 @@ export function buildAlertFiltersString(
         s === "pyp" ||
         s === "row52" ||
         s === "autorecycler" ||
-        s === "pullapart",
+        s === "pullapart" ||
+        s === "upullitne",
     ),
   );
   if (sourcesClause) clauses.push(sourcesClause);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,6 +12,12 @@ export const API_ENDPOINTS = {
   VEHICLE_INVENTORY:
     "/DesktopModules/pyp_vehicleInventory/getVehicleInventory.aspx",
   LOCATION_PAGE: "/inventory/",
+  PULLAPART_WEB: "https://www.pullapart.com",
+  UPULLANDPAY_WEB: "https://www.upullandpay.com",
+  PULLAPART_INVENTORY_BASE: "https://inventoryservice.pullapart.com",
+  PULLAPART_ENTERPRISE_BASE: "https://enterpriseservice.pullapart.com",
+  PULLAPART_EXTERNAL_INTERCHANGE_BASE:
+    "https://externalinterchangeservice.pullapart.com",
   ROW52_BASE: "https://api.row52.com",
   ROW52_WEB: "https://row52.com",
   PYP_FILTER_INVENTORY: "/DesktopModules/pyp_api/api/Inventory/Filter",

--- a/src/lib/saved-search-filters.ts
+++ b/src/lib/saved-search-filters.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const SOURCE_VALUES = ["pyp", "row52", "autorecycler"] as const;
+const SOURCE_VALUES = ["pyp", "row52", "autorecycler", "pullapart"] as const;
 const MIN_VEHICLE_YEAR = 1886;
 const MAX_VEHICLE_YEAR = new Date().getUTCFullYear() + 1;
 

--- a/src/lib/saved-search-filters.ts
+++ b/src/lib/saved-search-filters.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
-const SOURCE_VALUES = ["pyp", "row52", "autorecycler", "pullapart"] as const;
+const SOURCE_VALUES = [
+  "pyp",
+  "row52",
+  "autorecycler",
+  "pullapart",
+  "upullitne",
+] as const;
 const MIN_VEHICLE_YEAR = 1886;
 const MAX_VEHICLE_YEAR = new Date().getUTCFullYear() + 1;
 

--- a/src/lib/search-vehicles.ts
+++ b/src/lib/search-vehicles.ts
@@ -6,7 +6,8 @@ function parseDataSource(value: unknown): DataSource {
     value === "pyp" ||
     value === "row52" ||
     value === "autorecycler" ||
-    value === "pullapart"
+    value === "pullapart" ||
+    value === "upullitne"
   ) {
     return value;
   }

--- a/src/lib/search-vehicles.ts
+++ b/src/lib/search-vehicles.ts
@@ -2,7 +2,12 @@ import { calculateDistance } from "~/lib/utils";
 import type { DataSource, SearchVehicle } from "~/lib/types";
 
 function parseDataSource(value: unknown): DataSource {
-  if (value === "pyp" || value === "row52" || value === "autorecycler") {
+  if (
+    value === "pyp" ||
+    value === "row52" ||
+    value === "autorecycler" ||
+    value === "pullapart"
+  ) {
     return value;
   }
   return "pyp";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,9 @@
-export type DataSource = "pyp" | "row52" | "autorecycler" | "pullapart";
+export type DataSource =
+  | "pyp"
+  | "row52"
+  | "autorecycler"
+  | "pullapart"
+  | "upullitne";
 
 // Location types based on the PYP _locationList structure
 export interface Location {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type DataSource = "pyp" | "row52" | "autorecycler";
+export type DataSource = "pyp" | "row52" | "autorecycler" | "pullapart";
 
 // Location types based on the PYP _locationList structure
 export interface Location {

--- a/src/server/api/routers/status.ts
+++ b/src/server/api/routers/status.ts
@@ -11,13 +11,14 @@ import {
   type IngestionStatus,
 } from "./status-utils";
 
-const SOURCES = ["pyp", "row52", "autorecycler"] as const;
+const SOURCES = ["pyp", "row52", "autorecycler", "pullapart"] as const;
 type SourceKey = (typeof SOURCES)[number];
 
 const SOURCE_DISPLAY_NAMES: Record<SourceKey, string> = {
   pyp: "LKQ Pick Your Part",
   row52: "Row52",
   autorecycler: "AutoRecycler.io",
+  pullapart: "Pull-A-Part / U-Pull-&-Pay",
 };
 
 interface ProviderStatus {

--- a/src/server/api/routers/status.ts
+++ b/src/server/api/routers/status.ts
@@ -11,7 +11,13 @@ import {
   type IngestionStatus,
 } from "./status-utils";
 
-const SOURCES = ["pyp", "row52", "autorecycler", "pullapart"] as const;
+const SOURCES = [
+  "pyp",
+  "row52",
+  "autorecycler",
+  "pullapart",
+  "upullitne",
+] as const;
 type SourceKey = (typeof SOURCES)[number];
 
 const SOURCE_DISPLAY_NAMES: Record<SourceKey, string> = {
@@ -19,6 +25,7 @@ const SOURCE_DISPLAY_NAMES: Record<SourceKey, string> = {
   row52: "Row52",
   autorecycler: "AutoRecycler.io",
   pullapart: "Pull-A-Part / U-Pull-&-Pay",
+  upullitne: "U Pull-It Nebraska",
 };
 
 interface ProviderStatus {

--- a/src/server/ingestion/algolia-projector-helpers.ts
+++ b/src/server/ingestion/algolia-projector-helpers.ts
@@ -9,6 +9,8 @@ export function mapDbVehicleToCanonical(
       ? "row52"
       : row.source === "pullapart"
         ? "pullapart"
+      : row.source === "upullitne"
+        ? "upullitne"
       : row.source === "autorecycler"
         ? "autorecycler"
         : "pyp";

--- a/src/server/ingestion/algolia-projector-helpers.ts
+++ b/src/server/ingestion/algolia-projector-helpers.ts
@@ -7,6 +7,8 @@ export function mapDbVehicleToCanonical(
   const source: CanonicalVehicle["source"] =
     row.source === "row52"
       ? "row52"
+      : row.source === "pullapart"
+        ? "pullapart"
       : row.source === "autorecycler"
         ? "autorecycler"
         : "pyp";

--- a/src/server/ingestion/errors.ts
+++ b/src/server/ingestion/errors.ts
@@ -71,6 +71,17 @@ export class PullapartProviderError extends Data.TaggedError(
   }
 }
 
+export class TapInventoryProviderError extends Data.TaggedError(
+  "TapInventoryProviderError",
+)<{
+  cursor: string;
+  cause: unknown;
+}> {
+  override get message() {
+    return `TAP inventory at ${this.cursor}: ${getCauseMessage(this.cause)}`;
+  }
+}
+
 export class BrowserSessionError extends Data.TaggedError(
   "BrowserSessionError",
 )<{
@@ -115,6 +126,7 @@ export type IngestionError =
   | Row52ProviderError
   | AutorecyclerProviderError
   | PullapartProviderError
+  | TapInventoryProviderError
   | BrowserSessionError
   | ReconcileError
   | PersistenceError

--- a/src/server/ingestion/errors.ts
+++ b/src/server/ingestion/errors.ts
@@ -60,6 +60,17 @@ export class AutorecyclerProviderError extends Data.TaggedError(
   }
 }
 
+export class PullapartProviderError extends Data.TaggedError(
+  "PullapartProviderError",
+)<{
+  queryIndex: number;
+  cause: unknown;
+}> {
+  override get message() {
+    return `Pull-A-Part at query=${this.queryIndex}: ${getCauseMessage(this.cause)}`;
+  }
+}
+
 export class BrowserSessionError extends Data.TaggedError(
   "BrowserSessionError",
 )<{
@@ -103,6 +114,7 @@ export type IngestionError =
   | PypProviderError
   | Row52ProviderError
   | AutorecyclerProviderError
+  | PullapartProviderError
   | BrowserSessionError
   | ReconcileError
   | PersistenceError

--- a/src/server/ingestion/errors.ts
+++ b/src/server/ingestion/errors.ts
@@ -63,11 +63,11 @@ export class AutorecyclerProviderError extends Data.TaggedError(
 export class PullapartProviderError extends Data.TaggedError(
   "PullapartProviderError",
 )<{
-  queryIndex: number;
+  cursor: string;
   cause: unknown;
 }> {
   override get message() {
-    return `Pull-A-Part at query=${this.queryIndex}: ${getCauseMessage(this.cause)}`;
+    return `Pull-A-Part at ${this.cursor}: ${getCauseMessage(this.cause)}`;
   }
 }
 

--- a/src/server/ingestion/pipeline-policy.test.ts
+++ b/src/server/ingestion/pipeline-policy.test.ts
@@ -11,12 +11,14 @@ describe("pipeline policy", () => {
       { source: "row52", count: 120000, errors: [] },
       { source: "pyp", count: 70000, errors: [] },
       { source: "autorecycler", count: 5000, errors: [] },
+      { source: "pullapart", count: 25000, errors: [] },
     ];
 
     expect(determineHealthySources(outcomes)).toEqual([
       "row52",
       "pyp",
       "autorecycler",
+      "pullapart",
     ]);
     expect(shouldAdvanceMissingState(outcomes)).toBe(true);
   });
@@ -30,9 +32,14 @@ describe("pipeline policy", () => {
         errors: ["PYP returned only 0 locations (expected 20+)"],
       },
       { source: "autorecycler", count: 100, errors: [] },
+      { source: "pullapart", count: 25000, errors: [] },
     ];
 
-    expect(determineHealthySources(outcomes)).toEqual(["row52", "autorecycler"]);
+    expect(determineHealthySources(outcomes)).toEqual([
+      "row52",
+      "autorecycler",
+      "pullapart",
+    ]);
     expect(shouldAdvanceMissingState(outcomes)).toBe(false);
   });
 
@@ -41,6 +48,7 @@ describe("pipeline policy", () => {
       { source: "row52", count: 0, errors: ["Row52 failed"] },
       { source: "pyp", count: 0, errors: ["PYP failed"] },
       { source: "autorecycler", count: 0, errors: ["AutoRecycler failed"] },
+      { source: "pullapart", count: 0, errors: ["Pull-A-Part failed"] },
     ];
 
     expect(determineHealthySources(outcomes)).toEqual([]);

--- a/src/server/ingestion/pipeline-policy.test.ts
+++ b/src/server/ingestion/pipeline-policy.test.ts
@@ -12,6 +12,7 @@ describe("pipeline policy", () => {
       { source: "pyp", count: 70000, errors: [] },
       { source: "autorecycler", count: 5000, errors: [] },
       { source: "pullapart", count: 25000, errors: [] },
+      { source: "upullitne", count: 2486, errors: [] },
     ];
 
     expect(determineHealthySources(outcomes)).toEqual([
@@ -19,6 +20,7 @@ describe("pipeline policy", () => {
       "pyp",
       "autorecycler",
       "pullapart",
+      "upullitne",
     ]);
     expect(shouldAdvanceMissingState(outcomes)).toBe(true);
   });
@@ -33,12 +35,14 @@ describe("pipeline policy", () => {
       },
       { source: "autorecycler", count: 100, errors: [] },
       { source: "pullapart", count: 25000, errors: [] },
+      { source: "upullitne", count: 2486, errors: [] },
     ];
 
     expect(determineHealthySources(outcomes)).toEqual([
       "row52",
       "autorecycler",
       "pullapart",
+      "upullitne",
     ]);
     expect(shouldAdvanceMissingState(outcomes)).toBe(false);
   });
@@ -49,6 +53,7 @@ describe("pipeline policy", () => {
       { source: "pyp", count: 0, errors: ["PYP failed"] },
       { source: "autorecycler", count: 0, errors: ["AutoRecycler failed"] },
       { source: "pullapart", count: 0, errors: ["Pull-A-Part failed"] },
+      { source: "upullitne", count: 0, errors: ["U Pull-It Nebraska failed"] },
     ];
 
     expect(determineHealthySources(outcomes)).toEqual([]);

--- a/src/server/ingestion/pipeline-policy.ts
+++ b/src/server/ingestion/pipeline-policy.ts
@@ -2,7 +2,8 @@ export type PipelineSourceName =
   | "pyp"
   | "row52"
   | "autorecycler"
-  | "pullapart";
+  | "pullapart"
+  | "upullitne";
 
 export interface PipelineSourceOutcome {
   source: PipelineSourceName;

--- a/src/server/ingestion/pipeline-policy.ts
+++ b/src/server/ingestion/pipeline-policy.ts
@@ -1,4 +1,8 @@
-export type PipelineSourceName = "pyp" | "row52" | "autorecycler";
+export type PipelineSourceName =
+  | "pyp"
+  | "row52"
+  | "autorecycler"
+  | "pullapart";
 
 export interface PipelineSourceOutcome {
   source: PipelineSourceName;

--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -56,7 +56,11 @@ function pullapartJsonRequest<T, I, R>(params: {
           : new Error(String(cause)),
     });
 
-    if (DEFAULT_RETRYABLE_STATUS_CODES.includes(response.status)) {
+    if (
+      DEFAULT_RETRYABLE_STATUS_CODES.includes(
+        response.status as (typeof DEFAULT_RETRYABLE_STATUS_CODES)[number],
+      )
+    ) {
       return yield* Effect.fail(
         new RetryableHttpStatusError({
           context: params.context,
@@ -138,7 +142,7 @@ export const PullapartVehicleSchema = Schema.Struct({
   modelYear: Schema.Number,
   row: Schema.Union(Schema.Number, Schema.String),
   vin: Schema.String,
-  dateYardOn: Schema.String,
+  dateYardOn: Schema.NullOr(Schema.String),
   vinDecodedId: Schema.NullOr(Schema.Number),
   extendedInfo: Schema.NullOr(Schema.Unknown),
 });
@@ -187,7 +191,7 @@ export function fetchPullapartLocations(): Effect.Effect<
     url: `${API_ENDPOINTS.PULLAPART_EXTERNAL_INTERCHANGE_BASE}/interchange/GetLocations`,
     context: "Pull-A-Part locations",
     schema: Schema.Array(PullapartLocationSchema),
-  });
+  }).pipe(Effect.map((locations) => [...locations]));
 }
 
 export function fetchPullapartMakesOnYard(
@@ -201,7 +205,7 @@ export function fetchPullapartMakesOnYard(
     url: url.toString(),
     context: `Pull-A-Part makes on yard for location=${locationId}`,
     schema: Schema.Array(PullapartMakeSchema),
-  });
+  }).pipe(Effect.map((makes) => [...makes]));
 }
 
 export function searchPullapartVehicles(params: {
@@ -219,7 +223,7 @@ export function searchPullapartVehicles(params: {
       Models: [],
       Years: [],
     }),
-  });
+  }).pipe(Effect.map((groups) => [...groups]));
 }
 
 export const fetchPullapartVehiclesByMake = searchPullapartVehicles;
@@ -227,7 +231,7 @@ export const fetchPullapartVehiclesByMake = searchPullapartVehicles;
 export function fetchZipGeo(
   zipCode: string,
 ): Effect.Effect<PullapartZipGeo, Error> {
-  const normalizedZipCode = zipCode.trim();
+  const normalizedZipCode = zipCode.trim().slice(0, 5);
   return Effect.gen(function* () {
     const response = yield* pullapartJsonRequest({
       url: `https://api.zippopotam.us/us/${normalizedZipCode}`,

--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -1,0 +1,254 @@
+import { Duration, Effect, Schedule, Schema } from "effect";
+import { API_ENDPOINTS } from "~/lib/constants";
+import {
+  RequestTimeoutError,
+  RetryableHttpStatusError,
+} from "./errors";
+
+const DEFAULT_RETRYABLE_STATUS_CODES = [429, 502, 503, 504] as const;
+const FETCH_TIMEOUT_MS = 30_000;
+const RETRY_LIMIT = 2;
+const RETRY_BASE_DELAY_MS = 1_000;
+
+function isRetryablePullapartError(error: unknown): boolean {
+  return (
+    error instanceof RetryableHttpStatusError ||
+    error instanceof RequestTimeoutError
+  );
+}
+
+function buildRetrySchedule() {
+  return Schedule.intersect(
+    Schedule.recurs(RETRY_LIMIT),
+    Schedule.exponential(Duration.millis(RETRY_BASE_DELAY_MS), 2),
+  );
+}
+
+function pullapartJsonRequest<T, I, R>(params: {
+  url: string;
+  context: string;
+  schema: Schema.Schema<T, I, R>;
+  method?: "GET" | "POST";
+  body?: string;
+}): Effect.Effect<T, Error, R> {
+  const retrySchedule = buildRetrySchedule();
+
+  return Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(params.url, {
+          method: params.method ?? "GET",
+          body: params.body,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            Accept: "application/json",
+            ...(params.body ? { "Content-Type": "application/json" } : {}),
+          },
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        }),
+      catch: (cause) =>
+        cause instanceof DOMException && cause.name === "TimeoutError"
+          ? new RequestTimeoutError({
+              context: params.context,
+              cause: new Error(`Timed out after ${FETCH_TIMEOUT_MS}ms`),
+            })
+          : new Error(String(cause)),
+    });
+
+    if (DEFAULT_RETRYABLE_STATUS_CODES.includes(response.status)) {
+      return yield* Effect.fail(
+        new RetryableHttpStatusError({
+          context: params.context,
+          status: response.status,
+        }),
+      );
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      return yield* Effect.fail(
+        new Error(`${params.context} API error: ${response.status}`),
+      );
+    }
+
+    const json = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (cause) =>
+        new Error(`${params.context} returned invalid JSON: ${String(cause)}`),
+    });
+    return yield* Schema.decodeUnknown(params.schema)(json);
+  }).pipe(
+    Effect.retry(
+      retrySchedule.pipe(
+        Schedule.whileInput<Error>((error) => isRetryablePullapartError(error)),
+      ),
+    ),
+  );
+}
+
+export const PullapartMakeSchema = Schema.Struct({
+  makeID: Schema.Number,
+  makeName: Schema.String,
+  rareFind: Schema.Boolean,
+  dateModified: Schema.String,
+  dateCreated: Schema.String,
+});
+
+export type PullapartMake = Schema.Schema.Type<typeof PullapartMakeSchema>;
+
+export const PullapartLocationSchema = Schema.Struct({
+  idNumber: Schema.Number,
+  nameItem: Schema.String,
+  locationID: Schema.Number,
+  locationName: Schema.String,
+  address1: Schema.String,
+  address2: Schema.String,
+  cityName: Schema.String,
+  stateName: Schema.String,
+  zipCode: Schema.String,
+  siteTypeID: Schema.Number,
+  phone: Schema.String,
+  phoneCarBuying: Schema.String,
+  phoneUsedCar: Schema.NullOr(Schema.String),
+  distanceInMiles: Schema.Number,
+  taxRate: Schema.Number,
+  warrantyDays: Schema.Number,
+  coreDays: Schema.Number,
+  allowsCashReturns: Schema.Number,
+  email: Schema.String,
+  passcodeForMiscItems: Schema.Union(Schema.Boolean, Schema.String),
+  retailEmail: Schema.String,
+  environmentalFeeRate: Schema.Number,
+  environmentalFeeCap: Schema.Number,
+  locationShortName: Schema.String,
+});
+
+export type PullapartLocation = Schema.Schema.Type<typeof PullapartLocationSchema>;
+
+export const PullapartVehicleSchema = Schema.Struct({
+  vinID: Schema.Number,
+  ticketID: Schema.Number,
+  lineID: Schema.Number,
+  locID: Schema.Number,
+  locName: Schema.String,
+  makeID: Schema.Number,
+  makeName: Schema.String,
+  modelID: Schema.Number,
+  modelName: Schema.String,
+  modelYear: Schema.Number,
+  row: Schema.Union(Schema.Number, Schema.String),
+  vin: Schema.String,
+  dateYardOn: Schema.String,
+  vinDecodedId: Schema.NullOr(Schema.Number),
+  extendedInfo: Schema.NullOr(Schema.Unknown),
+});
+
+export type PullapartVehicle = Schema.Schema.Type<typeof PullapartVehicleSchema>;
+export type PullapartSearchVehicle = PullapartVehicle;
+
+export const PullapartVehicleSearchGroupSchema = Schema.Struct({
+  locationID: Schema.Number,
+  exact: Schema.Array(PullapartVehicleSchema),
+  other: Schema.Array(PullapartVehicleSchema),
+  inventory: Schema.NullOr(Schema.Unknown),
+});
+
+export type PullapartVehicleSearchGroup = Schema.Schema.Type<
+  typeof PullapartVehicleSearchGroupSchema
+>;
+
+export interface ResolvedPullapartLocation extends PullapartLocation {
+  lat: number;
+  lng: number;
+}
+
+const PullapartZipGeoSchema = Schema.Struct({
+  places: Schema.Array(
+    Schema.Struct({
+      latitude: Schema.String,
+      longitude: Schema.String,
+      "place name": Schema.String,
+      state: Schema.String,
+      "state abbreviation": Schema.String,
+    }),
+  ),
+});
+
+export interface PullapartZipGeo {
+  lat: number;
+  lng: number;
+}
+
+export function fetchPullapartLocations(): Effect.Effect<
+  PullapartLocation[],
+  Error
+> {
+  return pullapartJsonRequest({
+    url: `${API_ENDPOINTS.PULLAPART_EXTERNAL_INTERCHANGE_BASE}/interchange/GetLocations`,
+    context: "Pull-A-Part locations",
+    schema: Schema.Array(PullapartLocationSchema),
+  });
+}
+
+export function fetchPullapartMakesOnYard(
+  locationId: number,
+): Effect.Effect<PullapartMake[], Error> {
+  const url = new URL(
+    `${API_ENDPOINTS.PULLAPART_INVENTORY_BASE}/Make/OnYard`,
+  );
+  url.searchParams.set("locations", String(locationId));
+  return pullapartJsonRequest({
+    url: url.toString(),
+    context: `Pull-A-Part makes on yard for location=${locationId}`,
+    schema: Schema.Array(PullapartMakeSchema),
+  });
+}
+
+export function searchPullapartVehicles(params: {
+  locationId: number;
+  makeId: number;
+}): Effect.Effect<PullapartVehicleSearchGroup[], Error> {
+  return pullapartJsonRequest({
+    url: `${API_ENDPOINTS.PULLAPART_INVENTORY_BASE}/Vehicle/Search`,
+    context: `Pull-A-Part vehicle search location=${params.locationId} make=${params.makeId}`,
+    schema: Schema.Array(PullapartVehicleSearchGroupSchema),
+    method: "POST",
+    body: JSON.stringify({
+      Locations: [params.locationId],
+      MakeID: params.makeId,
+      Models: [],
+      Years: [],
+    }),
+  });
+}
+
+export const fetchPullapartVehiclesByMake = searchPullapartVehicles;
+
+export function fetchZipGeo(
+  zipCode: string,
+): Effect.Effect<PullapartZipGeo, Error> {
+  const normalizedZipCode = zipCode.trim();
+  return Effect.gen(function* () {
+    const response = yield* pullapartJsonRequest({
+      url: `https://api.zippopotam.us/us/${normalizedZipCode}`,
+      context: `ZIP geocode ${normalizedZipCode}`,
+      schema: PullapartZipGeoSchema,
+    });
+    const place = response.places[0];
+    if (!place) {
+      return yield* Effect.fail(
+        new Error(`ZIP geocode ${normalizedZipCode} returned no places`),
+      );
+    }
+
+    const lat = Number.parseFloat(place.latitude);
+    const lng = Number.parseFloat(place.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return yield* Effect.fail(
+        new Error(`ZIP geocode ${normalizedZipCode} returned invalid coordinates`),
+      );
+    }
+
+    return { lat, lng };
+  });
+}

--- a/src/server/ingestion/pullapart-connector.ts
+++ b/src/server/ingestion/pullapart-connector.ts
@@ -1,0 +1,171 @@
+import { Effect } from "effect";
+import {
+  fetchPullapartLocations,
+  fetchPullapartMakesOnYard,
+  searchPullapartVehicles,
+} from "./pullapart-client";
+import { DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL } from "./constants";
+import { PullapartProviderError } from "./errors";
+import { transformPullapartVehicle } from "./pullapart-transform";
+import type { CanonicalVehicle } from "./types";
+
+export interface PullapartStreamResult {
+  source: "pullapart";
+  count: number;
+  errors: string[];
+  pagesProcessed: number;
+  nextCursor: string;
+  done: boolean;
+  fullyExhausted: boolean;
+  stopped: boolean;
+}
+
+type PullapartProgress = {
+  nextCursor: string;
+  pagesProcessed: number;
+  vehiclesProcessed: number;
+  fullyExhausted: boolean;
+  stopped: boolean;
+  errors: string[];
+};
+
+export function streamPullapartInventory<E, R>(options: {
+  onBatch: (vehicles: CanonicalVehicle[]) => Effect.Effect<void, E, R>;
+  pagesPerChunk?: number;
+  onProgress?: (
+    progress: PullapartProgress,
+  ) => Effect.Effect<void, E, R>;
+}): Effect.Effect<
+  PullapartStreamResult,
+  PullapartProviderError | E,
+  R | import("@effect/platform").HttpClient.HttpClient
+> {
+  return Effect.gen(function* () {
+    const progressEveryPages = Math.max(
+      1,
+      options.pagesPerChunk ?? DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL,
+    );
+    let pagesProcessed = 0;
+    let vehiclesProcessed = 0;
+    let nextCursor = "0:0";
+    let fullyExhausted = false;
+    let stopped = false;
+    let lastProgressPages = 0;
+    const errors: string[] = [];
+
+    const emitProgress = (force: boolean): Effect.Effect<void, E, R> => {
+      if (!options.onProgress) return Effect.succeed(undefined);
+      if (!force && pagesProcessed - lastProgressPages < progressEveryPages) {
+        return Effect.succeed(undefined);
+      }
+      lastProgressPages = pagesProcessed;
+      return options.onProgress({
+        nextCursor,
+        pagesProcessed,
+        vehiclesProcessed,
+        fullyExhausted,
+        stopped,
+        errors,
+      });
+    };
+
+    const locations = yield* fetchPullapartLocations().pipe(
+      Effect.mapError(
+        (cause) => new PullapartProviderError({ cursor: "locations", cause }),
+      ),
+    );
+
+    yield* Effect.logInfo(
+      `[Pull-A-Part] Streaming inventory from ${locations.length} locations`,
+    );
+
+    for (
+      let locationIndex = 0;
+      locationIndex < locations.length && !stopped;
+      locationIndex += 1
+    ) {
+      const location = locations[locationIndex]!;
+      const cursorPrefix = `${location.locationID}`;
+
+      const makes = yield* fetchPullapartMakesOnYard(location.locationID).pipe(
+        Effect.mapError(
+          (cause) =>
+            new PullapartProviderError({
+              cursor: `${cursorPrefix}:makes`,
+              cause,
+            }),
+        ),
+      );
+
+      yield* Effect.logInfo(
+        `[Pull-A-Part] Location ${location.locationID} (${location.locationName}): ${makes.length} makes on yard`,
+      );
+
+      for (
+        let makeIndex = 0;
+        makeIndex < makes.length && !stopped;
+        makeIndex += 1
+      ) {
+        const make = makes[makeIndex]!;
+        nextCursor = `${location.locationID}:${make.makeID}`;
+
+        const response = yield* searchPullapartVehicles({
+          locationId: location.locationID,
+          makeId: make.makeID,
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new PullapartProviderError({
+                cursor: `${cursorPrefix}:make:${make.makeID}`,
+                cause,
+              }),
+          ),
+        );
+
+        const groupedResult = response.find(
+          (entry) => entry.locationID === location.locationID,
+        );
+        const rows = [
+          ...(groupedResult?.exact ?? []),
+          ...(groupedResult?.other ?? []),
+        ];
+
+        const uniqueByVin = new Map<string, CanonicalVehicle>();
+        for (const row of rows) {
+          const transformed = transformPullapartVehicle(row, location);
+          if (!transformed) continue;
+          uniqueByVin.set(transformed.vin, transformed);
+        }
+
+        const batch = [...uniqueByVin.values()];
+        if (batch.length > 0) {
+          yield* options.onBatch(batch);
+        }
+
+        vehiclesProcessed += batch.length;
+        pagesProcessed += 1;
+
+        yield* Effect.logInfo(
+          `[Pull-A-Part] Location ${location.locationID} make ${make.makeName}: ${batch.length} vehicles`,
+        );
+        yield* emitProgress(false);
+      }
+    }
+
+    if (!stopped) {
+      fullyExhausted = true;
+      yield* emitProgress(true);
+    }
+
+    return {
+      source: "pullapart" as const,
+      count: vehiclesProcessed,
+      errors,
+      pagesProcessed,
+      nextCursor,
+      done: true,
+      fullyExhausted,
+      stopped,
+    };
+  });
+}

--- a/src/server/ingestion/pullapart-connector.ts
+++ b/src/server/ingestion/pullapart-connector.ts
@@ -1,5 +1,7 @@
+import { HttpClient } from "@effect/platform";
 import { Effect } from "effect";
 import {
+  fetchZipGeo,
   fetchPullapartLocations,
   fetchPullapartMakesOnYard,
   searchPullapartVehicles,
@@ -38,8 +40,11 @@ export function streamPullapartInventory<E, R>(options: {
 }): Effect.Effect<
   PullapartStreamResult,
   PullapartProviderError | E,
-  R | import("@effect/platform").HttpClient.HttpClient
+  R | HttpClient.HttpClient
 > {
+  const makeQueryIndex = (locationIndex: number, makeIndex: number) =>
+    locationIndex * 1000 + makeIndex;
+
   return Effect.gen(function* () {
     const progressEveryPages = Math.max(
       1,
@@ -52,6 +57,7 @@ export function streamPullapartInventory<E, R>(options: {
     let stopped = false;
     let lastProgressPages = 0;
     const errors: string[] = [];
+    const geoByZip = new Map<string, { lat: number; lng: number }>();
 
     const emitProgress = (force: boolean): Effect.Effect<void, E, R> => {
       if (!options.onProgress) return Effect.succeed(undefined);
@@ -91,7 +97,7 @@ export function streamPullapartInventory<E, R>(options: {
         Effect.mapError(
           (cause) =>
             new PullapartProviderError({
-              cursor: `${cursorPrefix}:makes`,
+              cursor: `${cursorPrefix}:makes:${makeQueryIndex(locationIndex, -1)}`,
               cause,
             }),
         ),
@@ -116,7 +122,7 @@ export function streamPullapartInventory<E, R>(options: {
           Effect.mapError(
             (cause) =>
               new PullapartProviderError({
-                cursor: `${cursorPrefix}:make:${make.makeID}`,
+                cursor: `${cursorPrefix}:make:${make.makeID}:${makeQueryIndex(locationIndex, makeIndex)}`,
                 cause,
               }),
           ),
@@ -129,10 +135,23 @@ export function streamPullapartInventory<E, R>(options: {
           ...(groupedResult?.exact ?? []),
           ...(groupedResult?.other ?? []),
         ];
+        let geo = geoByZip.get(location.zipCode);
+        if (!geo) {
+          geo = yield* fetchZipGeo(location.zipCode).pipe(
+            Effect.mapError(
+              (cause) =>
+                new PullapartProviderError({
+                  cursor: `${cursorPrefix}:geo`,
+                  cause,
+                }),
+            ),
+          );
+          geoByZip.set(location.zipCode, geo);
+        }
 
         const uniqueByVin = new Map<string, CanonicalVehicle>();
         for (const row of rows) {
-          const transformed = transformPullapartVehicle(row, location);
+          const transformed = transformPullapartVehicle(row, location, geo);
           if (!transformed) continue;
           uniqueByVin.set(transformed.vin, transformed);
         }

--- a/src/server/ingestion/pullapart-transform.ts
+++ b/src/server/ingestion/pullapart-transform.ts
@@ -11,6 +11,25 @@ import type {
 } from "./pullapart-client";
 import type { CanonicalVehicle } from "./types";
 
+function readExtendedInfoField(
+  extendedInfo: unknown,
+  keys: ReadonlyArray<string>,
+): string | null {
+  if (!extendedInfo || typeof extendedInfo !== "object") {
+    return null;
+  }
+
+  const record = extendedInfo as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
 function buildDetailsUrl(
   location: PullapartLocation,
   vehicle: PullapartVehicle,
@@ -49,7 +68,7 @@ export function transformPullapartVehicle(
     make: normalizeCanonicalMake(vehicle.makeName),
     model: vehicle.modelName.trim(),
     color: normalizeCanonicalColor(
-      vehicle.extendedInfo?.color ?? vehicle.extendedInfo?.exteriorColor ?? null,
+      readExtendedInfoField(vehicle.extendedInfo, ["color", "exteriorColor"]),
     ),
     stockNumber: String(vehicle.ticketID),
     imageUrl: null,
@@ -70,12 +89,14 @@ export function transformPullapartVehicle(
     detailsUrl: buildDetailsUrl(location, vehicle),
     partsUrl: null,
     pricesUrl: null,
-    engine:
-      vehicle.extendedInfo?.engine ?? vehicle.extendedInfo?.engineDescription ?? null,
-    trim: vehicle.extendedInfo?.trim ?? null,
-    transmission:
-      vehicle.extendedInfo?.transmission ??
-      vehicle.extendedInfo?.transmissionDescription ??
-      null,
+    engine: readExtendedInfoField(vehicle.extendedInfo, [
+      "engine",
+      "engineDescription",
+    ]),
+    trim: readExtendedInfoField(vehicle.extendedInfo, ["trim"]),
+    transmission: readExtendedInfoField(vehicle.extendedInfo, [
+      "transmission",
+      "transmissionDescription",
+    ]),
   };
 }

--- a/src/server/ingestion/pullapart-transform.ts
+++ b/src/server/ingestion/pullapart-transform.ts
@@ -1,0 +1,81 @@
+import { API_ENDPOINTS } from "~/lib/constants";
+import {
+  normalizeCanonicalColor,
+  normalizeCanonicalMake,
+  normalizeRegion,
+} from "./normalization";
+import type {
+  PullapartLocation,
+  PullapartVehicle,
+  PullapartZipGeo,
+} from "./pullapart-client";
+import type { CanonicalVehicle } from "./types";
+
+function buildDetailsUrl(
+  location: PullapartLocation,
+  vehicle: PullapartVehicle,
+): string {
+  const baseHost =
+    location.siteTypeID === 5
+      ? API_ENDPOINTS.UPULLANDPAY_WEB
+      : API_ENDPOINTS.PULLAPART_WEB;
+  const query = new URLSearchParams({
+    LocationID: String(vehicle.locID),
+    LocationPage: "True",
+    Locations: String(vehicle.locID),
+    MakeID: String(vehicle.makeID),
+    Models: String(vehicle.modelID),
+    Years: String(vehicle.modelYear),
+  });
+  return `${baseHost}/inventory/search/?${query.toString()}#results`;
+}
+
+export function transformPullapartVehicle(
+  vehicle: PullapartVehicle,
+  location: PullapartLocation | undefined,
+  geo: PullapartZipGeo | undefined,
+): CanonicalVehicle | null {
+  if (!location) return null;
+  if (!geo) return null;
+  if (!vehicle.vin?.trim()) return null;
+  if (!vehicle.makeName?.trim() || !vehicle.modelName?.trim()) return null;
+
+  const region = normalizeRegion(location.stateName, location.stateName);
+
+  return {
+    vin: vehicle.vin.trim(),
+    source: "pullapart",
+    year: vehicle.modelYear,
+    make: normalizeCanonicalMake(vehicle.makeName),
+    model: vehicle.modelName.trim(),
+    color: normalizeCanonicalColor(
+      vehicle.extendedInfo?.color ?? vehicle.extendedInfo?.exteriorColor ?? null,
+    ),
+    stockNumber: String(vehicle.ticketID),
+    imageUrl: null,
+    availableDate: vehicle.dateYardOn || null,
+    locationCode: String(location.locationID),
+    locationName: location.locationName.trim(),
+    locationCity: location.cityName.trim() || "Unknown",
+    state: region.state,
+    stateAbbr: region.stateAbbr,
+    lat: geo.lat,
+    lng: geo.lng,
+    section: null,
+    row:
+      typeof vehicle.row === "number"
+        ? String(vehicle.row)
+        : vehicle.row?.toString().trim() || null,
+    space: null,
+    detailsUrl: buildDetailsUrl(location, vehicle),
+    partsUrl: null,
+    pricesUrl: null,
+    engine:
+      vehicle.extendedInfo?.engine ?? vehicle.extendedInfo?.engineDescription ?? null,
+    trim: vehicle.extendedInfo?.trim ?? null,
+    transmission:
+      vehicle.extendedInfo?.transmission ??
+      vehicle.extendedInfo?.transmissionDescription ??
+      null,
+  };
+}

--- a/src/server/ingestion/pullapart-transform.ts
+++ b/src/server/ingestion/pullapart-transform.ts
@@ -59,7 +59,7 @@ export function transformPullapartVehicle(
   if (!vehicle.vin?.trim()) return null;
   if (!vehicle.makeName?.trim() || !vehicle.modelName?.trim()) return null;
 
-  const region = normalizeRegion(location.stateName, location.stateName);
+  const region = normalizeRegion(location.stateName, null);
 
   return {
     vin: vehicle.vin.trim(),

--- a/src/server/ingestion/reconcile.test.ts
+++ b/src/server/ingestion/reconcile.test.ts
@@ -92,6 +92,7 @@ describe("reconcile helpers", () => {
       row52ByVin: new Map([[row52Vehicle.vin, row52Vehicle]]),
       pypByVin: new Map([[pypVehicle.vin, pypVehicle]]),
       autorecyclerByVin: new Map(),
+      pullapartByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN123")).toEqual(row52Vehicle);
@@ -112,6 +113,7 @@ describe("reconcile helpers", () => {
       row52ByVin: new Map([[row52Vehicle.vin, row52Vehicle]]),
       pypByVin: new Map([[pypVehicle.vin, pypVehicle]]),
       autorecyclerByVin: new Map(),
+      pullapartByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN123")).toEqual(pypVehicle);
@@ -128,10 +130,29 @@ describe("reconcile helpers", () => {
       row52ByVin: new Map([[row52Vehicle.vin, row52Vehicle]]),
       pypByVin: new Map(),
       autorecyclerByVin: new Map([[arVehicle.vin, arVehicle]]),
+      pullapartByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN_A")).toEqual(row52Vehicle);
     expect(finalInventory.get("VIN_B")).toEqual(arVehicle);
+  });
+
+  test("fills Pull-A-Part-only VINs after higher-priority sources merge", () => {
+    const row52Vehicle = makeCanonicalVehicle("VIN_A", "row52");
+    const pullapartVehicle = makeCanonicalVehicle("VIN_P", "pullapart", {
+      stockNumber: "PA-1",
+    });
+
+    const finalInventory = buildFinalInventoryByVin({
+      healthySources: ["row52", "pyp", "pullapart"],
+      row52ByVin: new Map([[row52Vehicle.vin, row52Vehicle]]),
+      pypByVin: new Map(),
+      autorecyclerByVin: new Map(),
+      pullapartByVin: new Map([[pullapartVehicle.vin, pullapartVehicle]]),
+    });
+
+    expect(finalInventory.get("VIN_A")).toEqual(row52Vehicle);
+    expect(finalInventory.get("VIN_P")).toEqual(pullapartVehicle);
   });
 
   test("treats reappearing vehicles as changed so missing state is cleared", () => {

--- a/src/server/ingestion/reconcile.test.ts
+++ b/src/server/ingestion/reconcile.test.ts
@@ -93,6 +93,7 @@ describe("reconcile helpers", () => {
       pypByVin: new Map([[pypVehicle.vin, pypVehicle]]),
       autorecyclerByVin: new Map(),
       pullapartByVin: new Map(),
+      upullitneByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN123")).toEqual(row52Vehicle);
@@ -114,6 +115,7 @@ describe("reconcile helpers", () => {
       pypByVin: new Map([[pypVehicle.vin, pypVehicle]]),
       autorecyclerByVin: new Map(),
       pullapartByVin: new Map(),
+      upullitneByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN123")).toEqual(pypVehicle);
@@ -131,6 +133,7 @@ describe("reconcile helpers", () => {
       pypByVin: new Map(),
       autorecyclerByVin: new Map([[arVehicle.vin, arVehicle]]),
       pullapartByVin: new Map(),
+      upullitneByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN_A")).toEqual(row52Vehicle);
@@ -149,6 +152,7 @@ describe("reconcile helpers", () => {
       pypByVin: new Map(),
       autorecyclerByVin: new Map(),
       pullapartByVin: new Map([[pullapartVehicle.vin, pullapartVehicle]]),
+      upullitneByVin: new Map(),
     });
 
     expect(finalInventory.get("VIN_A")).toEqual(row52Vehicle);

--- a/src/server/ingestion/reconcile.test.ts
+++ b/src/server/ingestion/reconcile.test.ts
@@ -155,6 +155,25 @@ describe("reconcile helpers", () => {
     expect(finalInventory.get("VIN_P")).toEqual(pullapartVehicle);
   });
 
+  test("fills U Pull-It-only VINs after higher-priority sources merge", () => {
+    const row52Vehicle = makeCanonicalVehicle("VIN_A", "row52");
+    const upullitneVehicle = makeCanonicalVehicle("VIN_U", "upullitne", {
+      stockNumber: "UPI-1",
+    });
+
+    const finalInventory = buildFinalInventoryByVin({
+      healthySources: ["row52", "pyp", "pullapart", "upullitne"],
+      row52ByVin: new Map([[row52Vehicle.vin, row52Vehicle]]),
+      pypByVin: new Map(),
+      autorecyclerByVin: new Map(),
+      pullapartByVin: new Map(),
+      upullitneByVin: new Map([[upullitneVehicle.vin, upullitneVehicle]]),
+    });
+
+    expect(finalInventory.get("VIN_A")).toEqual(row52Vehicle);
+    expect(finalInventory.get("VIN_U")).toEqual(upullitneVehicle);
+  });
+
   test("treats reappearing vehicles as changed so missing state is cleared", () => {
     const runTimestamp = new Date("2026-03-05T00:00:00.000Z");
     const finalInventory = new Map([

--- a/src/server/ingestion/reconcile.ts
+++ b/src/server/ingestion/reconcile.ts
@@ -69,56 +69,82 @@ export function buildFinalInventoryByVin(params: {
   row52ByVin: Map<string, CanonicalVehicle>;
   pypByVin: Map<string, CanonicalVehicle>;
   autorecyclerByVin: Map<string, CanonicalVehicle>;
+  pullapartByVin: Map<string, CanonicalVehicle>;
 }): Map<string, CanonicalVehicle> {
   const row52Healthy = params.healthySources.includes("row52");
   const pypHealthy = params.healthySources.includes("pyp");
   const autorecyclerHealthy = params.healthySources.includes("autorecycler");
+  const pullapartHealthy = params.healthySources.includes("pullapart");
 
-  const mergeAutorecyclerHoles = (into: Map<string, CanonicalVehicle>) => {
-    if (!autorecyclerHealthy) return;
-    for (const [vin, vehicle] of params.autorecyclerByVin) {
+  const mergeSourceHoles = (
+    into: Map<string, CanonicalVehicle>,
+    from: Map<string, CanonicalVehicle>,
+  ) => {
+    for (const [vin, vehicle] of from) {
       if (!into.has(vin)) {
         into.set(vin, vehicle);
       }
     }
   };
 
+  const mergeAutorecyclerHoles = (into: Map<string, CanonicalVehicle>) => {
+    if (!autorecyclerHealthy) return;
+    mergeSourceHoles(into, params.autorecyclerByVin);
+  };
+
+  const mergePullapartHoles = (into: Map<string, CanonicalVehicle>) => {
+    if (!pullapartHealthy) return;
+    mergeSourceHoles(into, params.pullapartByVin);
+  };
+
   if (row52Healthy && pypHealthy) {
-    // Row52 wins overlaps; PYP fills holes; AutoRecycler fills remaining holes.
-    for (const [vin, vehicle] of params.pypByVin) {
-      if (!params.row52ByVin.has(vin)) {
-        params.row52ByVin.set(vin, vehicle);
-      }
-    }
+    // Row52 wins overlaps; PYP fills holes; Pull-A-Part and AutoRecycler fill remaining holes.
+    mergeSourceHoles(params.row52ByVin, params.pypByVin);
     params.pypByVin.clear();
+    mergePullapartHoles(params.row52ByVin);
+    params.pullapartByVin.clear();
     mergeAutorecyclerHoles(params.row52ByVin);
     params.autorecyclerByVin.clear();
     return params.row52ByVin;
   }
 
   if (row52Healthy) {
+    mergePullapartHoles(params.row52ByVin);
     mergeAutorecyclerHoles(params.row52ByVin);
     params.pypByVin.clear();
+    params.pullapartByVin.clear();
     params.autorecyclerByVin.clear();
     return params.row52ByVin;
   }
 
   if (pypHealthy) {
+    mergePullapartHoles(params.pypByVin);
     mergeAutorecyclerHoles(params.pypByVin);
     params.row52ByVin.clear();
+    params.pullapartByVin.clear();
     params.autorecyclerByVin.clear();
     return params.pypByVin;
+  }
+
+  if (pullapartHealthy) {
+    mergeAutorecyclerHoles(params.pullapartByVin);
+    params.row52ByVin.clear();
+    params.pypByVin.clear();
+    params.autorecyclerByVin.clear();
+    return params.pullapartByVin;
   }
 
   if (autorecyclerHealthy) {
     params.row52ByVin.clear();
     params.pypByVin.clear();
+    params.pullapartByVin.clear();
     return params.autorecyclerByVin;
   }
 
   params.row52ByVin.clear();
   params.pypByVin.clear();
   params.autorecyclerByVin.clear();
+  params.pullapartByVin.clear();
   return new Map<string, CanonicalVehicle>();
 }
 

--- a/src/server/ingestion/reconcile.ts
+++ b/src/server/ingestion/reconcile.ts
@@ -70,11 +70,13 @@ export function buildFinalInventoryByVin(params: {
   pypByVin: Map<string, CanonicalVehicle>;
   autorecyclerByVin: Map<string, CanonicalVehicle>;
   pullapartByVin: Map<string, CanonicalVehicle>;
+  upullitneByVin: Map<string, CanonicalVehicle>;
 }): Map<string, CanonicalVehicle> {
   const row52Healthy = params.healthySources.includes("row52");
   const pypHealthy = params.healthySources.includes("pyp");
   const autorecyclerHealthy = params.healthySources.includes("autorecycler");
   const pullapartHealthy = params.healthySources.includes("pullapart");
+  const upullitneHealthy = params.healthySources.includes("upullitne");
 
   const mergeSourceHoles = (
     into: Map<string, CanonicalVehicle>,
@@ -97,12 +99,20 @@ export function buildFinalInventoryByVin(params: {
     mergeSourceHoles(into, params.pullapartByVin);
   };
 
+  const mergeUpullitneHoles = (into: Map<string, CanonicalVehicle>) => {
+    if (!upullitneHealthy) return;
+    mergeSourceHoles(into, params.upullitneByVin);
+  };
+
   if (row52Healthy && pypHealthy) {
-    // Row52 wins overlaps; PYP fills holes; Pull-A-Part and AutoRecycler fill remaining holes.
+    // Row52 wins overlaps; PYP fills holes; Pull-A-Part, U Pull-It Nebraska,
+    // and AutoRecycler fill remaining holes.
     mergeSourceHoles(params.row52ByVin, params.pypByVin);
     params.pypByVin.clear();
     mergePullapartHoles(params.row52ByVin);
     params.pullapartByVin.clear();
+    mergeUpullitneHoles(params.row52ByVin);
+    params.upullitneByVin.clear();
     mergeAutorecyclerHoles(params.row52ByVin);
     params.autorecyclerByVin.clear();
     return params.row52ByVin;
@@ -110,34 +120,50 @@ export function buildFinalInventoryByVin(params: {
 
   if (row52Healthy) {
     mergePullapartHoles(params.row52ByVin);
+    mergeUpullitneHoles(params.row52ByVin);
     mergeAutorecyclerHoles(params.row52ByVin);
     params.pypByVin.clear();
     params.pullapartByVin.clear();
+    params.upullitneByVin.clear();
     params.autorecyclerByVin.clear();
     return params.row52ByVin;
   }
 
   if (pypHealthy) {
     mergePullapartHoles(params.pypByVin);
+    mergeUpullitneHoles(params.pypByVin);
     mergeAutorecyclerHoles(params.pypByVin);
     params.row52ByVin.clear();
     params.pullapartByVin.clear();
+    params.upullitneByVin.clear();
     params.autorecyclerByVin.clear();
     return params.pypByVin;
   }
 
   if (pullapartHealthy) {
+    mergeUpullitneHoles(params.pullapartByVin);
     mergeAutorecyclerHoles(params.pullapartByVin);
     params.row52ByVin.clear();
     params.pypByVin.clear();
+    params.upullitneByVin.clear();
     params.autorecyclerByVin.clear();
     return params.pullapartByVin;
+  }
+
+  if (upullitneHealthy) {
+    mergeAutorecyclerHoles(params.upullitneByVin);
+    params.row52ByVin.clear();
+    params.pypByVin.clear();
+    params.pullapartByVin.clear();
+    params.autorecyclerByVin.clear();
+    return params.upullitneByVin;
   }
 
   if (autorecyclerHealthy) {
     params.row52ByVin.clear();
     params.pypByVin.clear();
     params.pullapartByVin.clear();
+    params.upullitneByVin.clear();
     return params.autorecyclerByVin;
   }
 
@@ -145,6 +171,7 @@ export function buildFinalInventoryByVin(params: {
   params.pypByVin.clear();
   params.autorecyclerByVin.clear();
   params.pullapartByVin.clear();
+  params.upullitneByVin.clear();
   return new Map<string, CanonicalVehicle>();
 }
 

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -1087,6 +1087,11 @@ export const ingestionPipeline: Effect.Effect<
       pullapartResult,
       upullitneResult,
     ];
+    const coreSourceOutcomes: SourceOutcome[] = [
+      row52Result,
+      pypResult,
+      autorecyclerResult,
+    ];
     const healthySources = determineHealthySources(sourceOutcomes);
     const reconcileTimestamp = new Date();
 
@@ -1126,7 +1131,8 @@ export const ingestionPipeline: Effect.Effect<
       runId,
       runTimestamp: reconcileTimestamp,
       finalInventoryByVin,
-      allowAdvanceMissingState: shouldAdvanceMissingState(sourceOutcomes),
+      allowAdvanceMissingState:
+        shouldAdvanceMissingState(coreSourceOutcomes),
       missingDeleteAfterRuns: MISSING_DELETE_AFTER_RUNS,
       missingDeleteAfterMs: MISSING_DELETE_AFTER_MS,
     }).pipe(

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -244,7 +244,8 @@ function isSourceName(value: string): value is SourceName {
     value === "row52" ||
     value === "pyp" ||
     value === "autorecycler" ||
-    value === "pullapart"
+    value === "pullapart" ||
+    value === "upullitne"
   );
 }
 

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -17,7 +17,7 @@ import {
 } from "./reconcile";
 import { streamAutorecyclerInventory } from "./autorecycler-connector";
 import { streamPullapartInventory } from "./pullapart-connector";
-import { streamUpullitneInventory } from "./tap-inventory-connector";
+import { streamTapInventory } from "./tap-inventory-connector";
 import { streamRow52Inventory } from "./row52-connector";
 import {
   PersistenceError,
@@ -904,7 +904,7 @@ function fetchUpullitneSource(
       );
     };
 
-    const result = yield* streamUpullitneInventory({
+    const result = yield* streamTapInventory({
       onBatch: (vehicles) =>
         Effect.sync(() => {
           accumulateVehicles(vehicleMap, vehicles);
@@ -912,17 +912,17 @@ function fetchUpullitneSource(
       pagesPerChunk: SOURCE_CHUNK_PAGES,
       onProgress: reportProgress,
     }).pipe(
-      Effect.tap((result) => {
-        latestNextCursor = result.nextCursor;
-        latestPagesProcessed = result.pagesProcessed;
-        latestVehiclesProcessed = result.count;
+      Effect.tap((tapResult) => {
+        latestNextCursor = tapResult.nextCursor;
+        latestPagesProcessed = tapResult.pagesProcessed;
+        latestVehiclesProcessed = tapResult.count;
         return completeSourceRun({
           runId,
           source: "upullitne",
-          nextCursor: result.nextCursor,
-          pagesProcessed: result.pagesProcessed,
-          vehiclesProcessed: result.count,
-          errors: result.errors,
+          nextCursor: tapResult.nextCursor,
+          pagesProcessed: tapResult.pagesProcessed,
+          vehiclesProcessed: tapResult.count,
+          errors: tapResult.errors,
         });
       }),
       Effect.tap(() =>
@@ -936,11 +936,11 @@ function fetchUpullitneSource(
           }),
         ),
       ),
-      Effect.catchAll((error) => {
+      Effect.catchAll((error: unknown) => {
         if (error instanceof PersistenceError) {
           return Effect.fail(error);
         }
-        const msg = `U Pull-It Nebraska ingestion failed: ${error.message}`;
+        const msg = `U Pull-It Nebraska ingestion failed: ${error instanceof Error ? error.message : String(error)}`;
         return completeSourceRun({
           runId,
           source: "upullitne",

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -16,6 +16,7 @@ import {
   reconcileFromFinalInventory,
 } from "./reconcile";
 import { streamAutorecyclerInventory } from "./autorecycler-connector";
+import { streamPullapartInventory } from "./pullapart-connector";
 import { streamRow52Inventory } from "./row52-connector";
 import {
   PersistenceError,
@@ -36,6 +37,7 @@ const EMPTY_TIMINGS = {
   row52FetchMs: 0,
   pypFetchMs: 0,
   autorecyclerFetchMs: 0,
+  pullapartFetchMs: 0,
   upsertFlushMs: 0,
   staleDeleteMs: 0,
   algoliaPrepMs: 0,
@@ -51,6 +53,7 @@ export interface IngestionPipelineResult {
   pypCount: number;
   row52Count: number;
   autorecyclerCount: number;
+  pullapartCount: number;
   errors: string[];
   durationMs: number;
   timingsMs: {
@@ -58,6 +61,7 @@ export interface IngestionPipelineResult {
     row52FetchMs: number;
     pypFetchMs: number;
     autorecyclerFetchMs: number;
+    pullapartFetchMs: number;
     upsertFlushMs: number;
     staleDeleteMs: number;
     algoliaPrepMs: number;
@@ -232,7 +236,12 @@ function parseSourceErrors(errorsJson: string | null): string[] {
 }
 
 function isSourceName(value: string): value is SourceName {
-  return value === "row52" || value === "pyp" || value === "autorecycler";
+  return (
+    value === "row52" ||
+    value === "pyp" ||
+    value === "autorecycler" ||
+    value === "pullapart"
+  );
 }
 
 const finalizePendingSourceRuns = (
@@ -748,6 +757,7 @@ export const ingestionPipeline: Effect.Effect<
       pypCount: 0,
       row52Count: 0,
       autorecyclerCount: 0,
+      pullapartCount: 0,
       errors: [msg],
       durationMs,
       timingsMs: EMPTY_TIMINGS,
@@ -759,15 +769,18 @@ export const ingestionPipeline: Effect.Effect<
       initSourceRun(runId, "row52", runTimestamp),
       initSourceRun(runId, "pyp", runTimestamp),
       initSourceRun(runId, "autorecycler", runTimestamp),
+      initSourceRun(runId, "pullapart", runTimestamp),
     ]);
 
     const row52ByVin = new Map<string, CanonicalVehicle>();
     const pypByVin = new Map<string, CanonicalVehicle>();
     const autorecyclerByVin = new Map<string, CanonicalVehicle>();
+    const pullapartByVin = new Map<string, CanonicalVehicle>();
 
     const sourcesStart = Date.now();
 
-    const [row52Result, pypResult, autorecyclerResult] = yield* Effect.all(
+    const [row52Result, pypResult, autorecyclerResult, pullapartResult] =
+      yield* Effect.all(
       [
         fetchRow52Source(runId, row52ByVin, {
           pyp: pypByVin,
@@ -781,8 +794,13 @@ export const ingestionPipeline: Effect.Effect<
           row52: row52ByVin,
           pyp: pypByVin,
         }),
+        fetchPullapartSource(runId, pullapartByVin, {
+          row52: row52ByVin,
+          pyp: pypByVin,
+          autorecycler: autorecyclerByVin,
+        }),
       ],
-      { concurrency: 3 },
+      { concurrency: 4 },
     );
 
     const sourcesParallelMs = Date.now() - sourcesStart;
@@ -790,12 +808,14 @@ export const ingestionPipeline: Effect.Effect<
       ...row52Result.errors,
       ...pypResult.errors,
       ...autorecyclerResult.errors,
+      ...pullapartResult.errors,
     );
 
     const sourceOutcomes: SourceOutcome[] = [
       row52Result,
       pypResult,
       autorecyclerResult,
+      pullapartResult,
     ];
     const healthySources = determineHealthySources(sourceOutcomes);
     const reconcileTimestamp = new Date();
@@ -805,6 +825,7 @@ export const ingestionPipeline: Effect.Effect<
         row52Vins: row52ByVin.size,
         pypVins: pypByVin.size,
         autorecyclerVins: autorecyclerByVin.size,
+        pullapartVins: pullapartByVin.size,
         healthySources: healthySources.join(",") || "none",
       }),
     );
@@ -814,6 +835,7 @@ export const ingestionPipeline: Effect.Effect<
       row52ByVin,
       pypByVin,
       autorecyclerByVin,
+      pullapartByVin,
     });
     const finalizedInventoryCount = finalInventoryByVin.size;
 
@@ -823,6 +845,7 @@ export const ingestionPipeline: Effect.Effect<
         row52Vins: row52ByVin.size,
         pypVins: pypByVin.size,
         autorecyclerVins: autorecyclerByVin.size,
+        pullapartVins: pullapartByVin.size,
       }),
     );
 
@@ -856,6 +879,7 @@ export const ingestionPipeline: Effect.Effect<
       row52FetchMs: row52Result.fetchMs,
       pypFetchMs: pypResult.fetchMs,
       autorecyclerFetchMs: autorecyclerResult.fetchMs,
+      pullapartFetchMs: pullapartResult.fetchMs,
       upsertFlushMs,
       staleDeleteMs,
       algoliaPrepMs: 0,
@@ -871,7 +895,7 @@ export const ingestionPipeline: Effect.Effect<
     );
 
     yield* Effect.logInfo(
-      `[Ingestion] PYP: ${pypResult.count} vehicles, Row52: ${row52Result.count} vehicles, AutoRecycler: ${autorecyclerResult.count} vehicles`,
+      `[Ingestion] PYP: ${pypResult.count} vehicles, Row52: ${row52Result.count} vehicles, AutoRecycler: ${autorecyclerResult.count} vehicles, Pull-A-Part: ${pullapartResult.count} vehicles`,
     );
     yield* Effect.logInfo(
       `[Ingestion] Finalized ${finalizedInventoryCount} canonical vehicles from healthy sources`,
@@ -880,7 +904,7 @@ export const ingestionPipeline: Effect.Effect<
       `[Ingestion] Reconcile complete: ${reconcileResult.upsertedCount} upserted, ${reconcileResult.deletedCount} deleted, ${reconcileResult.missingUpdatedCount} marked missing`,
     );
     yield* Effect.logInfo(
-      `[Ingestion] Source timings: row52=${row52Result.fetchMs}ms pyp=${pypResult.fetchMs}ms autorecycler=${autorecyclerResult.fetchMs}ms parallel_window=${sourcesParallelMs}ms`,
+      `[Ingestion] Source timings: row52=${row52Result.fetchMs}ms pyp=${pypResult.fetchMs}ms autorecycler=${autorecyclerResult.fetchMs}ms pullapart=${pullapartResult.fetchMs}ms parallel_window=${sourcesParallelMs}ms`,
     );
     yield* Effect.logInfo(
       `[Ingestion] Stage timings: inventory_diff_upsert=${upsertFlushMs}ms missing_delete=${staleDeleteMs}ms algolia_prep=0ms algolia_sync=0ms`,
@@ -902,6 +926,7 @@ export const ingestionPipeline: Effect.Effect<
       pypCount: pypResult.count,
       row52Count: row52Result.count,
       autorecyclerCount: autorecyclerResult.count,
+      pullapartCount: pullapartResult.count,
       errors: allErrors,
       durationMs,
       timingsMs,

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -17,6 +17,7 @@ import {
 } from "./reconcile";
 import { streamAutorecyclerInventory } from "./autorecycler-connector";
 import { streamPullapartInventory } from "./pullapart-connector";
+import { streamUpullitneInventory } from "./tap-inventory-connector";
 import { streamRow52Inventory } from "./row52-connector";
 import {
   PersistenceError,
@@ -38,6 +39,7 @@ const EMPTY_TIMINGS = {
   pypFetchMs: 0,
   autorecyclerFetchMs: 0,
   pullapartFetchMs: 0,
+  upullitneFetchMs: 0,
   upsertFlushMs: 0,
   staleDeleteMs: 0,
   algoliaPrepMs: 0,
@@ -54,6 +56,7 @@ export interface IngestionPipelineResult {
   row52Count: number;
   autorecyclerCount: number;
   pullapartCount: number;
+  upullitneCount: number;
   errors: string[];
   durationMs: number;
   timingsMs: {
@@ -62,6 +65,7 @@ export interface IngestionPipelineResult {
     pypFetchMs: number;
     autorecyclerFetchMs: number;
     pullapartFetchMs: number;
+    upullitneFetchMs: number;
     upsertFlushMs: number;
     staleDeleteMs: number;
     algoliaPrepMs: number;
@@ -853,6 +857,129 @@ function fetchPullapartSource(
   });
 }
 
+function fetchUpullitneSource(
+  runId: string,
+  vehicleMap: Map<string, CanonicalVehicle>,
+  peerMaps: {
+    row52: Map<string, CanonicalVehicle>;
+    pyp: Map<string, CanonicalVehicle>;
+    autorecycler: Map<string, CanonicalVehicle>;
+    pullapart: Map<string, CanonicalVehicle>;
+  },
+): Effect.Effect<SourceOutcome & { fetchMs: number }, PersistenceError> {
+  return Effect.gen(function* () {
+    const startedAt = Date.now();
+    let latestNextCursor = "0:0";
+    let latestPagesProcessed = 0;
+    let latestVehiclesProcessed = 0;
+    let latestProgressErrors: string[] = [];
+
+    const reportProgress = (progress: {
+      nextCursor: string;
+      pagesProcessed: number;
+      vehiclesProcessed: number;
+      errors: string[];
+    }) => {
+      latestNextCursor = progress.nextCursor;
+      latestPagesProcessed = progress.pagesProcessed;
+      latestVehiclesProcessed = progress.vehiclesProcessed;
+      latestProgressErrors = progress.errors;
+      return updateSourceRunProgress({
+        runId,
+        source: "upullitne",
+        nextCursor: progress.nextCursor,
+        pagesProcessed: progress.pagesProcessed,
+        vehiclesProcessed: progress.vehiclesProcessed,
+        errors: progress.errors,
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning(
+            `[Ingestion] U Pull-It Nebraska progress update failed: ${error.message}${
+              progress.errors.length > 0
+                ? ` (provider: ${progress.errors.join("; ")})`
+                : ""
+            }`,
+          ),
+        ),
+      );
+    };
+
+    const result = yield* streamUpullitneInventory({
+      onBatch: (vehicles) =>
+        Effect.sync(() => {
+          accumulateVehicles(vehicleMap, vehicles);
+        }),
+      pagesPerChunk: SOURCE_CHUNK_PAGES,
+      onProgress: reportProgress,
+    }).pipe(
+      Effect.tap((result) => {
+        latestNextCursor = result.nextCursor;
+        latestPagesProcessed = result.pagesProcessed;
+        latestVehiclesProcessed = result.count;
+        return completeSourceRun({
+          runId,
+          source: "upullitne",
+          nextCursor: result.nextCursor,
+          pagesProcessed: result.pagesProcessed,
+          vehiclesProcessed: result.count,
+          errors: result.errors,
+        });
+      }),
+      Effect.tap(() =>
+        Effect.logDebug(
+          formatMemoryUsage("after_upullitne_fetch", {
+            upullitneVins: vehicleMap.size,
+            peerRow52Vins: peerMaps.row52.size,
+            peerPypVins: peerMaps.pyp.size,
+            peerAutorecyclerVins: peerMaps.autorecycler.size,
+            peerPullapartVins: peerMaps.pullapart.size,
+          }),
+        ),
+      ),
+      Effect.catchAll((error) => {
+        if (error instanceof PersistenceError) {
+          return Effect.fail(error);
+        }
+        const msg = `U Pull-It Nebraska ingestion failed: ${error.message}`;
+        return completeSourceRun({
+          runId,
+          source: "upullitne",
+          nextCursor: latestNextCursor,
+          pagesProcessed: latestPagesProcessed,
+          vehiclesProcessed: latestVehiclesProcessed,
+          errors:
+            latestProgressErrors.length > 0
+              ? [...latestProgressErrors, msg]
+              : [msg],
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.logWarning(
+              `[Ingestion] completeSourceRun failed for source=upullitne runId=${runId}: ${err.message}`,
+            ),
+          ),
+          Effect.map(() => ({
+            source: "upullitne" as const,
+            count: latestVehiclesProcessed,
+            errors: [msg],
+            pagesProcessed: latestPagesProcessed,
+            nextCursor: latestNextCursor,
+            done: false,
+            fullyExhausted: false,
+            stopped: true,
+          })),
+        );
+      }),
+    );
+
+    return {
+      source: "upullitne" as const,
+      count: result.count,
+      errors: result.errors,
+      fetchMs: Date.now() - startedAt,
+    };
+  });
+}
+
 /**
  * Main ingestion pipeline as an Effect program.
  */
@@ -883,6 +1010,7 @@ export const ingestionPipeline: Effect.Effect<
       row52Count: 0,
       autorecyclerCount: 0,
       pullapartCount: 0,
+      upullitneCount: 0,
       errors: [msg],
       durationMs,
       timingsMs: EMPTY_TIMINGS,
@@ -895,16 +1023,24 @@ export const ingestionPipeline: Effect.Effect<
       initSourceRun(runId, "pyp", runTimestamp),
       initSourceRun(runId, "autorecycler", runTimestamp),
       initSourceRun(runId, "pullapart", runTimestamp),
+      initSourceRun(runId, "upullitne", runTimestamp),
     ]);
 
     const row52ByVin = new Map<string, CanonicalVehicle>();
     const pypByVin = new Map<string, CanonicalVehicle>();
     const autorecyclerByVin = new Map<string, CanonicalVehicle>();
     const pullapartByVin = new Map<string, CanonicalVehicle>();
+    const upullitneByVin = new Map<string, CanonicalVehicle>();
 
     const sourcesStart = Date.now();
 
-    const [row52Result, pypResult, autorecyclerResult, pullapartResult] =
+    const [
+      row52Result,
+      pypResult,
+      autorecyclerResult,
+      pullapartResult,
+      upullitneResult,
+    ] =
       yield* Effect.all(
       [
         fetchRow52Source(runId, row52ByVin, {
@@ -924,8 +1060,14 @@ export const ingestionPipeline: Effect.Effect<
           pyp: pypByVin,
           autorecycler: autorecyclerByVin,
         }),
+        fetchUpullitneSource(runId, upullitneByVin, {
+          row52: row52ByVin,
+          pyp: pypByVin,
+          autorecycler: autorecyclerByVin,
+          pullapart: pullapartByVin,
+        }),
       ],
-      { concurrency: 4 },
+      { concurrency: 5 },
     );
 
     const sourcesParallelMs = Date.now() - sourcesStart;
@@ -934,6 +1076,7 @@ export const ingestionPipeline: Effect.Effect<
       ...pypResult.errors,
       ...autorecyclerResult.errors,
       ...pullapartResult.errors,
+      ...upullitneResult.errors,
     );
 
     const sourceOutcomes: SourceOutcome[] = [
@@ -941,6 +1084,7 @@ export const ingestionPipeline: Effect.Effect<
       pypResult,
       autorecyclerResult,
       pullapartResult,
+      upullitneResult,
     ];
     const healthySources = determineHealthySources(sourceOutcomes);
     const reconcileTimestamp = new Date();
@@ -951,6 +1095,7 @@ export const ingestionPipeline: Effect.Effect<
         pypVins: pypByVin.size,
         autorecyclerVins: autorecyclerByVin.size,
         pullapartVins: pullapartByVin.size,
+        upullitneVins: upullitneByVin.size,
         healthySources: healthySources.join(",") || "none",
       }),
     );
@@ -961,6 +1106,7 @@ export const ingestionPipeline: Effect.Effect<
       pypByVin,
       autorecyclerByVin,
       pullapartByVin,
+      upullitneByVin,
     });
     const finalizedInventoryCount = finalInventoryByVin.size;
 
@@ -971,6 +1117,7 @@ export const ingestionPipeline: Effect.Effect<
         pypVins: pypByVin.size,
         autorecyclerVins: autorecyclerByVin.size,
         pullapartVins: pullapartByVin.size,
+        upullitneVins: upullitneByVin.size,
       }),
     );
 
@@ -1005,6 +1152,7 @@ export const ingestionPipeline: Effect.Effect<
       pypFetchMs: pypResult.fetchMs,
       autorecyclerFetchMs: autorecyclerResult.fetchMs,
       pullapartFetchMs: pullapartResult.fetchMs,
+      upullitneFetchMs: upullitneResult.fetchMs,
       upsertFlushMs,
       staleDeleteMs,
       algoliaPrepMs: 0,
@@ -1020,7 +1168,7 @@ export const ingestionPipeline: Effect.Effect<
     );
 
     yield* Effect.logInfo(
-      `[Ingestion] PYP: ${pypResult.count} vehicles, Row52: ${row52Result.count} vehicles, AutoRecycler: ${autorecyclerResult.count} vehicles, Pull-A-Part: ${pullapartResult.count} vehicles`,
+      `[Ingestion] PYP: ${pypResult.count} vehicles, Row52: ${row52Result.count} vehicles, AutoRecycler: ${autorecyclerResult.count} vehicles, Pull-A-Part: ${pullapartResult.count} vehicles, U Pull-It Nebraska: ${upullitneResult.count} vehicles`,
     );
     yield* Effect.logInfo(
       `[Ingestion] Finalized ${finalizedInventoryCount} canonical vehicles from healthy sources`,
@@ -1029,7 +1177,7 @@ export const ingestionPipeline: Effect.Effect<
       `[Ingestion] Reconcile complete: ${reconcileResult.upsertedCount} upserted, ${reconcileResult.deletedCount} deleted, ${reconcileResult.missingUpdatedCount} marked missing`,
     );
     yield* Effect.logInfo(
-      `[Ingestion] Source timings: row52=${row52Result.fetchMs}ms pyp=${pypResult.fetchMs}ms autorecycler=${autorecyclerResult.fetchMs}ms pullapart=${pullapartResult.fetchMs}ms parallel_window=${sourcesParallelMs}ms`,
+      `[Ingestion] Source timings: row52=${row52Result.fetchMs}ms pyp=${pypResult.fetchMs}ms autorecycler=${autorecyclerResult.fetchMs}ms pullapart=${pullapartResult.fetchMs}ms upullitne=${upullitneResult.fetchMs}ms parallel_window=${sourcesParallelMs}ms`,
     );
     yield* Effect.logInfo(
       `[Ingestion] Stage timings: inventory_diff_upsert=${upsertFlushMs}ms missing_delete=${staleDeleteMs}ms algolia_prep=0ms algolia_sync=0ms`,
@@ -1052,6 +1200,7 @@ export const ingestionPipeline: Effect.Effect<
       row52Count: row52Result.count,
       autorecyclerCount: autorecyclerResult.count,
       pullapartCount: pullapartResult.count,
+      upullitneCount: upullitneResult.count,
       errors: allErrors,
       durationMs,
       timingsMs,

--- a/src/server/ingestion/run-pipeline.ts
+++ b/src/server/ingestion/run-pipeline.ts
@@ -728,6 +728,131 @@ function fetchAutorecyclerSource(
   });
 }
 
+function fetchPullapartSource(
+  runId: string,
+  vehicleMap: Map<string, CanonicalVehicle>,
+  peerMaps: {
+    row52: Map<string, CanonicalVehicle>;
+    pyp: Map<string, CanonicalVehicle>;
+    autorecycler: Map<string, CanonicalVehicle>;
+  },
+): Effect.Effect<
+  SourceOutcome & { fetchMs: number },
+  PersistenceError,
+  HttpClient.HttpClient
+> {
+  return Effect.gen(function* () {
+    const startedAt = Date.now();
+    let latestNextCursor = "0:0";
+    let latestPagesProcessed = 0;
+    let latestVehiclesProcessed = 0;
+    let latestProgressErrors: string[] = [];
+
+    const reportProgress = (progress: {
+      nextCursor: string;
+      pagesProcessed: number;
+      vehiclesProcessed: number;
+      errors: string[];
+    }) => {
+      latestNextCursor = progress.nextCursor;
+      latestPagesProcessed = progress.pagesProcessed;
+      latestVehiclesProcessed = progress.vehiclesProcessed;
+      latestProgressErrors = progress.errors;
+      return updateSourceRunProgress({
+        runId,
+        source: "pullapart",
+        nextCursor: progress.nextCursor,
+        pagesProcessed: progress.pagesProcessed,
+        vehiclesProcessed: progress.vehiclesProcessed,
+        errors: progress.errors,
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning(
+            `[Ingestion] Pull-A-Part progress update failed: ${error.message}${
+              progress.errors.length > 0
+                ? ` (provider: ${progress.errors.join("; ")})`
+                : ""
+            }`,
+          ),
+        ),
+      );
+    };
+
+    const result = yield* streamPullapartInventory({
+      onBatch: (vehicles) =>
+        Effect.sync(() => {
+          accumulateVehicles(vehicleMap, vehicles);
+        }),
+      pagesPerChunk: SOURCE_CHUNK_PAGES,
+      onProgress: reportProgress,
+    }).pipe(
+      Effect.tap((result) => {
+        latestNextCursor = result.nextCursor;
+        latestPagesProcessed = result.pagesProcessed;
+        latestVehiclesProcessed = result.count;
+        return completeSourceRun({
+          runId,
+          source: "pullapart",
+          nextCursor: result.nextCursor,
+          pagesProcessed: result.pagesProcessed,
+          vehiclesProcessed: result.count,
+          errors: result.errors,
+        });
+      }),
+      Effect.tap(() =>
+        Effect.logDebug(
+          formatMemoryUsage("after_pullapart_fetch", {
+            pullapartVins: vehicleMap.size,
+            peerRow52Vins: peerMaps.row52.size,
+            peerPypVins: peerMaps.pyp.size,
+            peerAutorecyclerVins: peerMaps.autorecycler.size,
+          }),
+        ),
+      ),
+      Effect.catchAll((error) => {
+        if (error instanceof PersistenceError) {
+          return Effect.fail(error);
+        }
+        const msg = `Pull-A-Part ingestion failed: ${error.message}`;
+        return completeSourceRun({
+          runId,
+          source: "pullapart",
+          nextCursor: latestNextCursor,
+          pagesProcessed: latestPagesProcessed,
+          vehiclesProcessed: latestVehiclesProcessed,
+          errors:
+            latestProgressErrors.length > 0
+              ? [...latestProgressErrors, msg]
+              : [msg],
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.logWarning(
+              `[Ingestion] completeSourceRun failed for source=pullapart runId=${runId}: ${err.message}`,
+            ),
+          ),
+          Effect.map(() => ({
+            source: "pullapart" as const,
+            count: latestVehiclesProcessed,
+            errors: [msg],
+            pagesProcessed: latestPagesProcessed,
+            nextCursor: latestNextCursor,
+            done: false,
+            fullyExhausted: false,
+            stopped: true,
+          })),
+        );
+      }),
+    );
+
+    return {
+      source: "pullapart" as const,
+      count: result.count,
+      errors: result.errors,
+      fetchMs: Date.now() - startedAt,
+    };
+  });
+}
+
 /**
  * Main ingestion pipeline as an Effect program.
  */

--- a/src/server/ingestion/tap-inventory-client.ts
+++ b/src/server/ingestion/tap-inventory-client.ts
@@ -26,15 +26,17 @@ function buildRetrySchedule() {
 export interface TapInventorySiteConfig {
   source: "upullitne";
   siteName: string;
+  baseUrl: string;
   inventoryPageUrl: string;
   ajaxUrl: string;
   pluginUrl: string;
   nonce: string;
-  stores: Record<
+  storeLocations: Record<
     string,
     {
+      code: string;
       locationName: string;
-      locationCity: string;
+      city: string;
       state: string;
       stateAbbr: string;
       zipCode: string;
@@ -44,6 +46,7 @@ export interface TapInventorySiteConfig {
       lng: number;
     }
   >;
+  makes: string[];
 }
 
 function tapRequest<T, I, R>(params: {
@@ -133,7 +136,7 @@ export const TapInventorySearchProductSchema = Schema.Struct({
   hol_model: Schema.String,
   vehicle_row: Schema.String,
   yard_date: Schema.String,
-  yard_in_date: Schema.String,
+  yard_in_date: Schema.optional(Schema.String),
   batch_number: Schema.String,
   lastupdate: Schema.String,
   color: Schema.String,
@@ -195,6 +198,11 @@ function decodeHtmlOptions(text: string) {
   return Schema.decodeUnknownSync(HtmlOptionsSchema)(options);
 }
 
+export type TapInventoryOption = ReturnType<typeof decodeHtmlOptions>[number];
+export type TapStoreOption = TapInventoryOption;
+export type TapInventoryStoreConfig =
+  TapInventorySiteConfig["storeLocations"][string];
+
 export function fetchTapOptions(params: {
   ajaxUrl: string;
   nonce: string;
@@ -217,7 +225,27 @@ export function fetchTapOptions(params: {
       sif_verify_request: params.nonce,
       ...(params.extra ?? {}),
     },
-  }).pipe(Effect.map(decodeHtmlOptions));
+  }).pipe(Effect.map((options) => [...decodeHtmlOptions(options)]));
+}
+
+export function fetchTapStores(config: TapInventorySiteConfig) {
+  return fetchTapOptions({
+    ajaxUrl: config.ajaxUrl,
+    nonce: config.nonce,
+    action: "sif_get_stores",
+  });
+}
+
+export function fetchTapModels(config: TapInventorySiteConfig, make: string) {
+  return fetchTapOptions({
+    ajaxUrl: config.ajaxUrl,
+    nonce: config.nonce,
+    action: "sif_update_models",
+    extra: {
+      make,
+      state: "0",
+    },
+  });
 }
 
 export function searchTapInventory(params: {
@@ -242,3 +270,106 @@ export function searchTapInventory(params: {
     },
   }).pipe(Effect.map(decodeSearchResponse));
 }
+
+export const UPULLITNE_SITE_CONFIG: TapInventorySiteConfig = {
+  source: "upullitne",
+  siteName: "U Pull-It Nebraska",
+  baseUrl: "https://upullitne.com",
+  inventoryPageUrl: "https://upullitne.com/search-inventory/",
+  ajaxUrl: "https://upullitne.com/wp-admin/admin-ajax.php",
+  pluginUrl:
+    "https://upullitne.com/wp-content/plugins/tap-inventory-search-system/",
+  nonce: "2ff54e61b2",
+  storeLocations: {
+    LINCOLN: {
+      code: "LINCOLN",
+      locationName: "U Pull-It Nebraska - Lincoln",
+      city: "Lincoln",
+      state: "Nebraska",
+      stateAbbr: "NE",
+      zipCode: "68507",
+      phone: "402-467-4101",
+      address: "6300 N. 70th Street",
+      lat: 40.8715,
+      lng: -96.6256,
+    },
+    "OMAHA NORTH": {
+      code: "OMAHA NORTH",
+      locationName: "U Pull-It Nebraska - Omaha North",
+      city: "Omaha",
+      state: "Nebraska",
+      stateAbbr: "NE",
+      zipCode: "68110",
+      phone: "402-342-0831",
+      address: "1405 Grace Street",
+      lat: 41.2801,
+      lng: -95.9658,
+    },
+    "OMAHA SOUTH": {
+      code: "OMAHA SOUTH",
+      locationName: "U Pull-It Nebraska - Omaha South",
+      city: "Omaha",
+      state: "Nebraska",
+      stateAbbr: "NE",
+      zipCode: "68117",
+      phone: "402-734-6029",
+      address: "5600 S. 60th Street",
+      lat: 41.2042,
+      lng: -96.0011,
+    },
+    "DES MOINES": {
+      code: "DES MOINES",
+      locationName: "U Pull-It Nebraska - Des Moines",
+      city: "Des Moines",
+      state: "Iowa",
+      stateAbbr: "IA",
+      zipCode: "50313",
+      phone: "515-528-3600",
+      address: "1600 NE 44th Ave",
+      lat: 41.6387,
+      lng: -93.5566,
+    },
+  },
+  makes: [
+    "ACURA",
+    "AUDI",
+    "BMW",
+    "BUICK",
+    "CADILLAC",
+    "CHEVROLET",
+    "CHRYSLER",
+    "DODGE",
+    "FIAT",
+    "FORD",
+    "GEO",
+    "GMC",
+    "HONDA",
+    "HUMMER",
+    "HYUNDAI",
+    "INFINITI",
+    "ISUZU",
+    "JAGUAR",
+    "JEEP",
+    "KIA",
+    "LAND ROVER",
+    "LEXUS",
+    "LINCOLN",
+    "MAZDA",
+    "MERCEDES-BENZ",
+    "MERCURY",
+    "MINI",
+    "MITSUBISHI",
+    "NISSAN",
+    "OLDSMOBILE",
+    "PLYMOUTH",
+    "PONTIAC",
+    "SAAB",
+    "SATURN",
+    "SCION",
+    "SUBARU",
+    "SUZUKI",
+    "TOYOTA",
+    "VOLKSWAGEN",
+    "VOLVO",
+  ],
+};

--- a/src/server/ingestion/tap-inventory-client.ts
+++ b/src/server/ingestion/tap-inventory-client.ts
@@ -332,7 +332,18 @@ export function searchTapInventory(params: {
           "sorting[state]": "0",
           "sorting[type]": "int",
         },
-      }).pipe(Effect.flatMap(decodeSearchResponse)),
+      }).pipe(
+        Effect.flatMap(decodeSearchResponse),
+        Effect.flatMap((response) =>
+          response.success
+            ? Effect.succeed(response)
+            : Effect.fail(
+                new Error(
+                  `TAP inventory search failed for store=${params.store} make=${params.make} model=${params.model}: ${response.message || "unknown provider error"}`,
+                ),
+              ),
+        ),
+      ),
     ),
   );
 }

--- a/src/server/ingestion/tap-inventory-client.ts
+++ b/src/server/ingestion/tap-inventory-client.ts
@@ -30,7 +30,6 @@ export interface TapInventorySiteConfig {
   inventoryPageUrl: string;
   ajaxUrl: string;
   pluginUrl: string;
-  nonce: string;
   storeLocations: Record<
     string,
     {
@@ -118,6 +117,57 @@ function tapRequest<T, I, R>(params: {
   );
 }
 
+const TapInventoryBootstrapSchema = Schema.Struct({
+  ajaxUrl: Schema.String,
+  nonce: Schema.String,
+  pluginUrl: Schema.String,
+});
+
+export type TapInventoryBootstrap = Schema.Schema.Type<
+  typeof TapInventoryBootstrapSchema
+>;
+
+export function fetchTapBootstrap(
+  config: Pick<TapInventorySiteConfig, "inventoryPageUrl">,
+): Effect.Effect<TapInventoryBootstrap, Error> {
+  return Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(config.inventoryPageUrl, {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `TAP inventory page bootstrap error: HTTP ${response.status}`,
+        );
+      }
+
+      const html = await response.text();
+      const match =
+        /var\s+sif_ajax_object\s*=\s*\{"sif_ajax_url":"([^"]+)","sif_ajax_nonce":"([^"]+)","sif_plugin_url":"([^"]+)"\}/.exec(
+          html,
+        );
+
+      if (!match?.[1] || !match[2] || !match[3]) {
+        throw new Error("TAP inventory bootstrap payload not found in page HTML");
+      }
+
+      return Schema.decodeUnknownSync(TapInventoryBootstrapSchema)({
+        ajaxUrl: match[1],
+        nonce: match[2],
+        pluginUrl: match[3],
+      });
+    },
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(String(cause)),
+  });
+}
+
 export const TapInventorySearchProductSchema = Schema.Struct({
   s3clientid: Schema.String,
   crush_version: Schema.String,
@@ -130,10 +180,10 @@ export const TapInventorySearchProductSchema = Schema.Struct({
   iyear: Schema.String,
   make: Schema.String,
   model: Schema.String,
-  hol_year: Schema.String,
-  hol_mfr_code: Schema.String,
-  hol_mfr_name: Schema.String,
-  hol_model: Schema.String,
+  hol_year: Schema.optional(Schema.String),
+  hol_mfr_code: Schema.optional(Schema.String),
+  hol_mfr_name: Schema.optional(Schema.String),
+  hol_model: Schema.optional(Schema.String),
   vehicle_row: Schema.String,
   yard_date: Schema.String,
   yard_in_date: Schema.optional(Schema.String),
@@ -160,14 +210,18 @@ export type TapInventorySearchResponse = Schema.Schema.Type<
   typeof TapInventorySearchResponseSchema
 >;
 
-function decodeSearchResponse(text: string): TapInventorySearchResponse {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch (error) {
-    throw new Error(`TAP inventory search returned invalid JSON: ${String(error)}`);
-  }
-  return Schema.decodeUnknownSync(TapInventorySearchResponseSchema)(parsed);
+function decodeSearchResponse(
+  text: string,
+): Effect.Effect<TapInventorySearchResponse, Error> {
+  return Effect.try({
+    try: () => JSON.parse(text) as unknown,
+    catch: (cause) =>
+      new Error(`TAP inventory search returned invalid JSON: ${String(cause)}`),
+  }).pipe(
+    Effect.flatMap((parsed) =>
+      Schema.decodeUnknown(TapInventorySearchResponseSchema)(parsed),
+    ),
+  );
 }
 
 const HtmlOptionsSchema = Schema.Array(
@@ -229,23 +283,31 @@ export function fetchTapOptions(params: {
 }
 
 export function fetchTapStores(config: TapInventorySiteConfig) {
-  return fetchTapOptions({
-    ajaxUrl: config.ajaxUrl,
-    nonce: config.nonce,
-    action: "sif_get_stores",
-  });
+  return fetchTapBootstrap(config).pipe(
+    Effect.flatMap((bootstrap) =>
+      fetchTapOptions({
+        ajaxUrl: bootstrap.ajaxUrl,
+        nonce: bootstrap.nonce,
+        action: "sif_get_stores",
+      }),
+    ),
+  );
 }
 
 export function fetchTapModels(config: TapInventorySiteConfig, make: string) {
-  return fetchTapOptions({
-    ajaxUrl: config.ajaxUrl,
-    nonce: config.nonce,
-    action: "sif_update_models",
-    extra: {
-      make,
-      state: "0",
-    },
-  });
+  return fetchTapBootstrap(config).pipe(
+    Effect.flatMap((bootstrap) =>
+      fetchTapOptions({
+        ajaxUrl: bootstrap.ajaxUrl,
+        nonce: bootstrap.nonce,
+        action: "sif_update_models",
+        extra: {
+          make,
+          state: "0",
+        },
+      }),
+    ),
+  );
 }
 
 export function searchTapInventory(params: {
@@ -254,21 +316,25 @@ export function searchTapInventory(params: {
   make: string;
   model: string;
 }): Effect.Effect<TapInventorySearchResponse, Error> {
-  return tapRequest({
-    url: params.config.ajaxUrl,
-    context: `TAP inventory search store=${params.store} make=${params.make} model=${params.model}`,
-    schema: Schema.String,
-    formData: {
-      action: "sif_search_products",
-      sif_verify_request: params.config.nonce,
-      sif_form_field_store: params.store,
-      sif_form_field_make: params.make,
-      sif_form_field_model: params.model,
-      "sorting[key]": "iyear",
-      "sorting[state]": "0",
-      "sorting[type]": "int",
-    },
-  }).pipe(Effect.map(decodeSearchResponse));
+  return fetchTapBootstrap(params.config).pipe(
+    Effect.flatMap((bootstrap) =>
+      tapRequest({
+        url: bootstrap.ajaxUrl,
+        context: `TAP inventory search store=${params.store} make=${params.make} model=${params.model}`,
+        schema: Schema.String,
+        formData: {
+          action: "sif_search_products",
+          sif_verify_request: bootstrap.nonce,
+          sif_form_field_store: params.store,
+          sif_form_field_make: params.make,
+          sif_form_field_model: params.model,
+          "sorting[key]": "iyear",
+          "sorting[state]": "0",
+          "sorting[type]": "int",
+        },
+      }).pipe(Effect.flatMap(decodeSearchResponse)),
+    ),
+  );
 }
 
 export const UPULLITNE_SITE_CONFIG: TapInventorySiteConfig = {
@@ -279,7 +345,6 @@ export const UPULLITNE_SITE_CONFIG: TapInventorySiteConfig = {
   ajaxUrl: "https://upullitne.com/wp-admin/admin-ajax.php",
   pluginUrl:
     "https://upullitne.com/wp-content/plugins/tap-inventory-search-system/",
-  nonce: "2ff54e61b2",
   storeLocations: {
     LINCOLN: {
       code: "LINCOLN",

--- a/src/server/ingestion/tap-inventory-client.ts
+++ b/src/server/ingestion/tap-inventory-client.ts
@@ -1,0 +1,244 @@
+import { Duration, Effect, Schedule, Schema } from "effect";
+import {
+  RequestTimeoutError,
+  RetryableHttpStatusError,
+} from "./errors";
+
+const DEFAULT_RETRYABLE_STATUS_CODES = [429, 502, 503, 504] as const;
+const FETCH_TIMEOUT_MS = 30_000;
+const RETRY_LIMIT = 2;
+const RETRY_BASE_DELAY_MS = 1_000;
+
+function isRetryableTapError(error: unknown): boolean {
+  return (
+    error instanceof RetryableHttpStatusError ||
+    error instanceof RequestTimeoutError
+  );
+}
+
+function buildRetrySchedule() {
+  return Schedule.intersect(
+    Schedule.recurs(RETRY_LIMIT),
+    Schedule.exponential(Duration.millis(RETRY_BASE_DELAY_MS), 2),
+  );
+}
+
+export interface TapInventorySiteConfig {
+  source: "upullitne";
+  siteName: string;
+  inventoryPageUrl: string;
+  ajaxUrl: string;
+  pluginUrl: string;
+  nonce: string;
+  stores: Record<
+    string,
+    {
+      locationName: string;
+      locationCity: string;
+      state: string;
+      stateAbbr: string;
+      zipCode: string;
+      phone: string;
+      address: string;
+      lat: number;
+      lng: number;
+    }
+  >;
+}
+
+function tapRequest<T, I, R>(params: {
+  url: string;
+  context: string;
+  schema: Schema.Schema<T, I, R>;
+  formData: Record<string, string>;
+}): Effect.Effect<T, Error, R> {
+  const retrySchedule = buildRetrySchedule();
+
+  return Effect.gen(function* () {
+    const body = new URLSearchParams(params.formData).toString();
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(params.url, {
+          method: "POST",
+          body,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            Accept: "application/json, text/html;q=0.9, */*;q=0.8",
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+            Referer: params.url,
+          },
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        }),
+      catch: (cause) =>
+        cause instanceof DOMException && cause.name === "TimeoutError"
+          ? new RequestTimeoutError({
+              context: params.context,
+              cause: new Error(`Timed out after ${FETCH_TIMEOUT_MS}ms`),
+            })
+          : new Error(String(cause)),
+    });
+
+    if (
+      DEFAULT_RETRYABLE_STATUS_CODES.includes(
+        response.status as (typeof DEFAULT_RETRYABLE_STATUS_CODES)[number],
+      )
+    ) {
+      return yield* Effect.fail(
+        new RetryableHttpStatusError({
+          context: params.context,
+          status: response.status,
+        }),
+      );
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      return yield* Effect.fail(
+        new Error(`${params.context} API error: ${response.status}`),
+      );
+    }
+
+    const text = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (cause) =>
+        new Error(`${params.context} returned unreadable body: ${String(cause)}`),
+    });
+
+    return yield* Schema.decodeUnknown(params.schema)(text);
+  }).pipe(
+    Effect.retry(
+      retrySchedule.pipe(
+        Schedule.whileInput<Error>((error) => isRetryableTapError(error)),
+      ),
+    ),
+  );
+}
+
+export const TapInventorySearchProductSchema = Schema.Struct({
+  s3clientid: Schema.String,
+  crush_version: Schema.String,
+  yard_name: Schema.String,
+  yard_city: Schema.String,
+  yard_state: Schema.String,
+  stocknumber: Schema.String,
+  istatus: Schema.String,
+  location: Schema.String,
+  iyear: Schema.String,
+  make: Schema.String,
+  model: Schema.String,
+  hol_year: Schema.String,
+  hol_mfr_code: Schema.String,
+  hol_mfr_name: Schema.String,
+  hol_model: Schema.String,
+  vehicle_row: Schema.String,
+  yard_date: Schema.String,
+  yard_in_date: Schema.String,
+  batch_number: Schema.String,
+  lastupdate: Schema.String,
+  color: Schema.String,
+  vin: Schema.String,
+  reference: Schema.String,
+  mileage: Schema.String,
+  image_url: Schema.String,
+});
+
+export type TapInventorySearchProduct = Schema.Schema.Type<
+  typeof TapInventorySearchProductSchema
+>;
+
+const TapInventorySearchResponseSchema = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+  products: Schema.Array(TapInventorySearchProductSchema),
+});
+
+export type TapInventorySearchResponse = Schema.Schema.Type<
+  typeof TapInventorySearchResponseSchema
+>;
+
+function decodeSearchResponse(text: string): TapInventorySearchResponse {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`TAP inventory search returned invalid JSON: ${String(error)}`);
+  }
+  return Schema.decodeUnknownSync(TapInventorySearchResponseSchema)(parsed);
+}
+
+const HtmlOptionsSchema = Schema.Array(
+  Schema.Struct({
+    value: Schema.String,
+    label: Schema.String,
+    selected: Schema.Boolean,
+  }),
+);
+
+function decodeHtmlOptions(text: string) {
+  const optionRegex = /<option\s+value="([^"]*)"([^>]*)>([\s\S]*?)<\/option>/gi;
+  const options: Array<{
+    value: string;
+    label: string;
+    selected: boolean;
+  }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = optionRegex.exec(text)) !== null) {
+    const [, value = "", attrs = "", rawLabel = ""] = match;
+    const label = rawLabel.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+    options.push({
+      value,
+      label,
+      selected: /\bselected\b/i.test(attrs),
+    });
+  }
+  return Schema.decodeUnknownSync(HtmlOptionsSchema)(options);
+}
+
+export function fetchTapOptions(params: {
+  ajaxUrl: string;
+  nonce: string;
+  action:
+    | "sif_get_stores"
+    | "sif_get_locations"
+    | "sif_get_makes"
+    | "sif_update_models";
+  extra?: Record<string, string>;
+}): Effect.Effect<
+  Array<{ value: string; label: string; selected: boolean }>,
+  Error
+> {
+  return tapRequest({
+    url: params.ajaxUrl,
+    context: `TAP option request ${params.action}`,
+    schema: Schema.String,
+    formData: {
+      action: params.action,
+      sif_verify_request: params.nonce,
+      ...(params.extra ?? {}),
+    },
+  }).pipe(Effect.map(decodeHtmlOptions));
+}
+
+export function searchTapInventory(params: {
+  config: TapInventorySiteConfig;
+  store: string;
+  make: string;
+  model: string;
+}): Effect.Effect<TapInventorySearchResponse, Error> {
+  return tapRequest({
+    url: params.config.ajaxUrl,
+    context: `TAP inventory search store=${params.store} make=${params.make} model=${params.model}`,
+    schema: Schema.String,
+    formData: {
+      action: "sif_search_products",
+      sif_verify_request: params.config.nonce,
+      sif_form_field_store: params.store,
+      sif_form_field_make: params.make,
+      sif_form_field_model: params.model,
+      "sorting[key]": "iyear",
+      "sorting[state]": "0",
+      "sorting[type]": "int",
+    },
+  }).pipe(Effect.map(decodeSearchResponse));
+}

--- a/src/server/ingestion/tap-inventory-connector.ts
+++ b/src/server/ingestion/tap-inventory-connector.ts
@@ -1,0 +1,177 @@
+import { Effect } from "effect";
+import {
+  fetchTapModels,
+  fetchTapStores,
+  searchTapInventory,
+  UPULLITNE_SITE_CONFIG,
+  type TapStoreOption,
+} from "./tap-inventory-client";
+import { DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL } from "./constants";
+import { TapProviderError } from "./errors";
+import { transformTapInventoryProduct } from "./tap-inventory-transform";
+import type { CanonicalVehicle } from "./types";
+
+export interface TapStreamResult {
+  source: "upullitne";
+  count: number;
+  errors: string[];
+  pagesProcessed: number;
+  nextCursor: string;
+  done: boolean;
+  fullyExhausted: boolean;
+  stopped: boolean;
+}
+
+type TapProgress = {
+  nextCursor: string;
+  pagesProcessed: number;
+  vehiclesProcessed: number;
+  fullyExhausted: boolean;
+  stopped: boolean;
+  errors: string[];
+};
+
+function makeTapCursor(store: string, make: string): string {
+  return `${store}:${make}`;
+}
+
+export function streamTapInventory<E, R>(options: {
+  onBatch: (vehicles: CanonicalVehicle[]) => Effect.Effect<void, E, R>;
+  pagesPerChunk?: number;
+  onProgress?: (progress: TapProgress) => Effect.Effect<void, E, R>;
+}): Effect.Effect<TapStreamResult, TapProviderError | E, R> {
+  return Effect.gen(function* () {
+    const progressEveryPages = Math.max(
+      1,
+      options.pagesPerChunk ?? DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL,
+    );
+    let pagesProcessed = 0;
+    let vehiclesProcessed = 0;
+    let nextCursor = "0:0";
+    let fullyExhausted = false;
+    let stopped = false;
+    let lastProgressPages = 0;
+    const errors: string[] = [];
+
+    const emitProgress = (force: boolean): Effect.Effect<void, E, R> => {
+      if (!options.onProgress) return Effect.succeed(undefined);
+      if (!force && pagesProcessed - lastProgressPages < progressEveryPages) {
+        return Effect.succeed(undefined);
+      }
+      lastProgressPages = pagesProcessed;
+      return options.onProgress({
+        nextCursor,
+        pagesProcessed,
+        vehiclesProcessed,
+        fullyExhausted,
+        stopped,
+        errors,
+      });
+    };
+
+    const stores = yield* fetchTapStores(UPULLITNE_SITE_CONFIG).pipe(
+      Effect.mapError(
+        (cause) => new TapProviderError({ cursor: "stores", cause }),
+      ),
+    );
+
+    yield* Effect.logInfo(
+      `[TAP/upullitne] Streaming inventory from ${stores.length} stores`,
+    );
+
+    for (
+      let storeIndex = 0;
+      storeIndex < stores.length && !stopped;
+      storeIndex += 1
+    ) {
+      const store = stores[storeIndex]!;
+      if (store.value === "Any") continue;
+
+      const storeConfig = UPULLITNE_SITE_CONFIG.storeLocations[store.value];
+      if (!storeConfig) {
+        const msg = `[TAP/upullitne] Missing store config for ${store.value}`;
+        errors.push(msg);
+        stopped = true;
+        break;
+      }
+
+      const makes = UPULLITNE_SITE_CONFIG.makes;
+
+      for (
+        let makeIndex = 0;
+        makeIndex < makes.length && !stopped;
+        makeIndex += 1
+      ) {
+        const make = makes[makeIndex]!;
+        nextCursor = makeTapCursor(store.value, make);
+
+        const models = yield* fetchTapModels(UPULLITNE_SITE_CONFIG, make).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TapProviderError({
+                cursor: `${nextCursor}:models`,
+                cause,
+              }),
+          ),
+        );
+
+        const modelValues = ["Any", ...models.map((model) => model.value)];
+        const seen = new Map<string, CanonicalVehicle>();
+
+        for (const modelValue of modelValues) {
+          const result = yield* searchTapInventory(UPULLITNE_SITE_CONFIG, {
+            store: store.value,
+            make,
+            model: modelValue,
+          }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new TapProviderError({
+                  cursor: `${nextCursor}:${modelValue}`,
+                  cause,
+                }),
+            ),
+          );
+
+          for (const product of result.products) {
+            const transformed = transformTapInventoryProduct(
+              product,
+              storeConfig,
+            );
+            if (!transformed) continue;
+            seen.set(transformed.vin, transformed);
+          }
+        }
+
+        const batch = [...seen.values()];
+        if (batch.length > 0) {
+          yield* options.onBatch(batch);
+        }
+
+        vehiclesProcessed += batch.length;
+        pagesProcessed += 1;
+
+        yield* Effect.logInfo(
+          `[TAP/upullitne] Store ${store.value} make ${make}: ${batch.length} vehicles`,
+        );
+        yield* emitProgress(false);
+      }
+    }
+
+    if (!stopped) {
+      fullyExhausted = true;
+      yield* emitProgress(true);
+    }
+
+    return {
+      source: "upullitne" as const,
+      count: vehiclesProcessed,
+      errors,
+      pagesProcessed,
+      nextCursor,
+      done: true,
+      fullyExhausted,
+      stopped,
+    };
+  });
+}

--- a/src/server/ingestion/tap-inventory-connector.ts
+++ b/src/server/ingestion/tap-inventory-connector.ts
@@ -85,18 +85,27 @@ export function streamTapInventory<E, R>(options: {
         (cause) => new TapInventoryProviderError({ cursor: "stores", cause }),
       ),
     );
+    const concreteStores = stores.filter((store) => store.value !== "Any");
+
+    if (concreteStores.length === 0) {
+      return yield* Effect.fail(
+        new TapInventoryProviderError({
+          cursor: "stores",
+          cause: new Error("TAP returned no concrete stores"),
+        }),
+      );
+    }
 
     yield* Effect.logInfo(
-      `[TAP/upullitne] Streaming inventory from ${stores.length} stores`,
+      `[TAP/upullitne] Streaming inventory from ${concreteStores.length} stores`,
     );
 
     for (
       let storeIndex = 0;
-      storeIndex < stores.length && !stopped;
+      storeIndex < concreteStores.length && !stopped;
       storeIndex += 1
     ) {
-      const store = stores[storeIndex]!;
-      if (store.value === "Any") continue;
+      const store = concreteStores[storeIndex]!;
 
       const storeConfig = config.storeLocations[store.value];
       if (!storeConfig) {

--- a/src/server/ingestion/tap-inventory-connector.ts
+++ b/src/server/ingestion/tap-inventory-connector.ts
@@ -7,7 +7,7 @@ import {
   type TapStoreOption,
 } from "./tap-inventory-client";
 import { DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL } from "./constants";
-import { TapProviderError } from "./errors";
+import { TapInventoryProviderError } from "./errors";
 import { transformTapInventoryProduct } from "./tap-inventory-transform";
 import type { CanonicalVehicle } from "./types";
 
@@ -39,7 +39,7 @@ export function streamTapInventory<E, R>(options: {
   onBatch: (vehicles: CanonicalVehicle[]) => Effect.Effect<void, E, R>;
   pagesPerChunk?: number;
   onProgress?: (progress: TapProgress) => Effect.Effect<void, E, R>;
-}): Effect.Effect<TapStreamResult, TapProviderError | E, R> {
+}): Effect.Effect<TapStreamResult, TapInventoryProviderError | E, R> {
   return Effect.gen(function* () {
     const progressEveryPages = Math.max(
       1,
@@ -71,7 +71,7 @@ export function streamTapInventory<E, R>(options: {
 
     const stores = yield* fetchTapStores(UPULLITNE_SITE_CONFIG).pipe(
       Effect.mapError(
-        (cause) => new TapProviderError({ cursor: "stores", cause }),
+        (cause) => new TapInventoryProviderError({ cursor: "stores", cause }),
       ),
     );
 
@@ -108,7 +108,7 @@ export function streamTapInventory<E, R>(options: {
         const models = yield* fetchTapModels(UPULLITNE_SITE_CONFIG, make).pipe(
           Effect.mapError(
             (cause) =>
-              new TapProviderError({
+              new TapInventoryProviderError({
                 cursor: `${nextCursor}:models`,
                 cause,
               }),
@@ -119,14 +119,15 @@ export function streamTapInventory<E, R>(options: {
         const seen = new Map<string, CanonicalVehicle>();
 
         for (const modelValue of modelValues) {
-          const result = yield* searchTapInventory(UPULLITNE_SITE_CONFIG, {
+          const result = yield* searchTapInventory({
+            config: UPULLITNE_SITE_CONFIG,
             store: store.value,
             make,
             model: modelValue,
           }).pipe(
             Effect.mapError(
               (cause) =>
-                new TapProviderError({
+                new TapInventoryProviderError({
                   cursor: `${nextCursor}:${modelValue}`,
                   cause,
                 }),
@@ -137,6 +138,7 @@ export function streamTapInventory<E, R>(options: {
             const transformed = transformTapInventoryProduct(
               product,
               storeConfig,
+              UPULLITNE_SITE_CONFIG,
             );
             if (!transformed) continue;
             seen.set(transformed.vin, transformed);

--- a/src/server/ingestion/tap-inventory-connector.ts
+++ b/src/server/ingestion/tap-inventory-connector.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import {
+  fetchTapBootstrap,
   fetchTapStores,
   searchTapInventory,
   UPULLITNE_SITE_CONFIG,
@@ -34,7 +35,22 @@ export function streamTapInventory<E, R>(options: {
   pagesPerChunk?: number;
   onProgress?: (progress: TapProgress) => Effect.Effect<void, E, R>;
 }): Effect.Effect<TapStreamResult, TapInventoryProviderError | E, R> {
+  const loadConfig: Effect.Effect<
+    typeof UPULLITNE_SITE_CONFIG,
+    TapInventoryProviderError
+  > = fetchTapBootstrap(UPULLITNE_SITE_CONFIG).pipe(
+    Effect.mapError(
+      (cause) => new TapInventoryProviderError({ cursor: "site-config", cause }),
+    ),
+    Effect.map((bootstrap) => ({
+      ...UPULLITNE_SITE_CONFIG,
+      ajaxUrl: bootstrap.ajaxUrl,
+      pluginUrl: bootstrap.pluginUrl,
+    })),
+  );
+
   return Effect.gen(function* () {
+    const config = yield* loadConfig;
     const progressEveryPages = Math.max(
       1,
       options.pagesPerChunk ?? DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL,
@@ -46,6 +62,7 @@ export function streamTapInventory<E, R>(options: {
     let stopped = false;
     let lastProgressPages = 0;
     const errors: string[] = [];
+    const globalSeen = new Map<string, CanonicalVehicle>();
 
     const emitProgress = (force: boolean): Effect.Effect<void, E, R> => {
       if (!options.onProgress) return Effect.succeed(undefined);
@@ -63,7 +80,7 @@ export function streamTapInventory<E, R>(options: {
       });
     };
 
-    const stores = yield* fetchTapStores(UPULLITNE_SITE_CONFIG).pipe(
+    const stores = yield* fetchTapStores(config).pipe(
       Effect.mapError(
         (cause) => new TapInventoryProviderError({ cursor: "stores", cause }),
       ),
@@ -81,7 +98,7 @@ export function streamTapInventory<E, R>(options: {
       const store = stores[storeIndex]!;
       if (store.value === "Any") continue;
 
-      const storeConfig = UPULLITNE_SITE_CONFIG.storeLocations[store.value];
+      const storeConfig = config.storeLocations[store.value];
       if (!storeConfig) {
         const msg = `[TAP/upullitne] Missing store config for ${store.value}`;
         errors.push(msg);
@@ -92,7 +109,7 @@ export function streamTapInventory<E, R>(options: {
       nextCursor = `${store.value}:store`;
 
       const result = yield* searchTapInventory({
-        config: UPULLITNE_SITE_CONFIG,
+        config,
         store: store.value,
         make: "Any",
         model: "Any",
@@ -106,18 +123,23 @@ export function streamTapInventory<E, R>(options: {
         ),
       );
 
-      const seen = new Map<string, CanonicalVehicle>();
+      const storeSeen = new Map<string, CanonicalVehicle>();
       for (const product of result.products) {
         const transformed = transformTapInventoryProduct(
           product,
           storeConfig,
-          UPULLITNE_SITE_CONFIG,
+          config,
         );
         if (!transformed) continue;
-        seen.set(transformed.vin, transformed);
+        storeSeen.set(transformed.vin, transformed);
       }
 
-      const batch = [...seen.values()];
+      const batch: CanonicalVehicle[] = [];
+      for (const [vin, vehicle] of storeSeen) {
+        if (globalSeen.has(vin)) continue;
+        globalSeen.set(vin, vehicle);
+        batch.push(vehicle);
+      }
       if (batch.length > 0) {
         yield* options.onBatch(batch);
       }

--- a/src/server/ingestion/tap-inventory-connector.ts
+++ b/src/server/ingestion/tap-inventory-connector.ts
@@ -1,10 +1,8 @@
 import { Effect } from "effect";
 import {
-  fetchTapModels,
   fetchTapStores,
   searchTapInventory,
   UPULLITNE_SITE_CONFIG,
-  type TapStoreOption,
 } from "./tap-inventory-client";
 import { DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL } from "./constants";
 import { TapInventoryProviderError } from "./errors";
@@ -30,10 +28,6 @@ type TapProgress = {
   stopped: boolean;
   errors: string[];
 };
-
-function makeTapCursor(store: string, make: string): string {
-  return `${store}:${make}`;
-}
 
 export function streamTapInventory<E, R>(options: {
   onBatch: (vehicles: CanonicalVehicle[]) => Effect.Effect<void, E, R>;
@@ -95,69 +89,46 @@ export function streamTapInventory<E, R>(options: {
         break;
       }
 
-      const makes = UPULLITNE_SITE_CONFIG.makes;
+      nextCursor = `${store.value}:store`;
 
-      for (
-        let makeIndex = 0;
-        makeIndex < makes.length && !stopped;
-        makeIndex += 1
-      ) {
-        const make = makes[makeIndex]!;
-        nextCursor = makeTapCursor(store.value, make);
+      const result = yield* searchTapInventory({
+        config: UPULLITNE_SITE_CONFIG,
+        store: store.value,
+        make: "Any",
+        model: "Any",
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TapInventoryProviderError({
+              cursor: nextCursor,
+              cause,
+            }),
+        ),
+      );
 
-        const models = yield* fetchTapModels(UPULLITNE_SITE_CONFIG, make).pipe(
-          Effect.mapError(
-            (cause) =>
-              new TapInventoryProviderError({
-                cursor: `${nextCursor}:models`,
-                cause,
-              }),
-          ),
+      const seen = new Map<string, CanonicalVehicle>();
+      for (const product of result.products) {
+        const transformed = transformTapInventoryProduct(
+          product,
+          storeConfig,
+          UPULLITNE_SITE_CONFIG,
         );
-
-        const modelValues = ["Any", ...models.map((model) => model.value)];
-        const seen = new Map<string, CanonicalVehicle>();
-
-        for (const modelValue of modelValues) {
-          const result = yield* searchTapInventory({
-            config: UPULLITNE_SITE_CONFIG,
-            store: store.value,
-            make,
-            model: modelValue,
-          }).pipe(
-            Effect.mapError(
-              (cause) =>
-                new TapInventoryProviderError({
-                  cursor: `${nextCursor}:${modelValue}`,
-                  cause,
-                }),
-            ),
-          );
-
-          for (const product of result.products) {
-            const transformed = transformTapInventoryProduct(
-              product,
-              storeConfig,
-              UPULLITNE_SITE_CONFIG,
-            );
-            if (!transformed) continue;
-            seen.set(transformed.vin, transformed);
-          }
-        }
-
-        const batch = [...seen.values()];
-        if (batch.length > 0) {
-          yield* options.onBatch(batch);
-        }
-
-        vehiclesProcessed += batch.length;
-        pagesProcessed += 1;
-
-        yield* Effect.logInfo(
-          `[TAP/upullitne] Store ${store.value} make ${make}: ${batch.length} vehicles`,
-        );
-        yield* emitProgress(false);
+        if (!transformed) continue;
+        seen.set(transformed.vin, transformed);
       }
+
+      const batch = [...seen.values()];
+      if (batch.length > 0) {
+        yield* options.onBatch(batch);
+      }
+
+      vehiclesProcessed += batch.length;
+      pagesProcessed += 1;
+
+      yield* Effect.logInfo(
+        `[TAP/upullitne] Store ${store.value}: ${batch.length} vehicles`,
+      );
+      yield* emitProgress(false);
     }
 
     if (!stopped) {

--- a/src/server/ingestion/tap-inventory-transform.ts
+++ b/src/server/ingestion/tap-inventory-transform.ts
@@ -1,0 +1,77 @@
+import { normalizeCanonicalColor, normalizeCanonicalMake } from "./normalization";
+import type {
+  TapInventoryProduct,
+  TapInventorySiteConfig,
+  TapInventoryStoreConfig,
+} from "./tap-inventory-client";
+import type { CanonicalVehicle } from "./types";
+
+function stripHtml(value: string): string {
+  return value.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function extractImageUrl(rawHtml: string): string | null {
+  const match = /<img[^>]+src=["']([^"']+)["']/i.exec(rawHtml);
+  return match?.[1]?.trim() || null;
+}
+
+export function transformTapInventoryProduct(
+  product: TapInventoryProduct,
+  store: TapInventoryStoreConfig,
+  site: TapInventorySiteConfig,
+): CanonicalVehicle | null {
+  const vin = product.vin.trim();
+  if (!vin) return null;
+
+  const parsedYear = Number.parseInt(product.iyear, 10);
+  if (!Number.isFinite(parsedYear) || parsedYear <= 0) {
+    return null;
+  }
+
+  const make = normalizeCanonicalMake(product.make);
+  const model = product.model.trim();
+  if (!model) return null;
+
+  const stockNumber = product.stocknumber.trim();
+  const imageUrl = extractImageUrl(product.image_url);
+  const detailsUrl =
+    stockNumber.length > 0
+      ? `${site.baseUrl}/search-inventory/?stock=${encodeURIComponent(stockNumber)}`
+      : `${site.baseUrl}/search-inventory/`;
+
+  return {
+    vin,
+    source: site.source,
+    year: parsedYear,
+    make,
+    model,
+    color: normalizeCanonicalColor(product.color),
+    stockNumber: stockNumber || null,
+    imageUrl,
+    availableDate: product.yard_in_date?.trim() || null,
+    locationCode: store.code,
+    locationName: store.locationName,
+    locationCity: store.city,
+    state: store.state,
+    stateAbbr: store.stateAbbr,
+    lat: store.lat,
+    lng: store.lng,
+    section: null,
+    row: product.vehicle_row.trim() || null,
+    space: null,
+    detailsUrl,
+    partsUrl: `${site.baseUrl}/parts-pricelist/`,
+    pricesUrl: `${site.baseUrl}/parts-pricelist/`,
+    engine: null,
+    trim: null,
+    transmission: null,
+  };
+}
+
+export function parseTapInventoryCount(messageHtml: string): number | null {
+  const text = stripHtml(messageHtml);
+  const match = /\b([\d,]+)\b\s*-\s*result\(s\)\s*found/i.exec(text);
+  if (!match?.[1]) return null;
+  const parsed = Number.parseInt(match[1].replaceAll(",", ""), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/src/server/ingestion/tap-inventory-transform.ts
+++ b/src/server/ingestion/tap-inventory-transform.ts
@@ -1,6 +1,6 @@
 import { normalizeCanonicalColor, normalizeCanonicalMake } from "./normalization";
 import type {
-  TapInventoryProduct,
+  TapInventorySearchProduct,
   TapInventorySiteConfig,
   TapInventoryStoreConfig,
 } from "./tap-inventory-client";
@@ -16,7 +16,7 @@ function extractImageUrl(rawHtml: string): string | null {
 }
 
 export function transformTapInventoryProduct(
-  product: TapInventoryProduct,
+  product: TapInventorySearchProduct,
   store: TapInventoryStoreConfig,
   site: TapInventorySiteConfig,
 ): CanonicalVehicle | null {
@@ -36,8 +36,8 @@ export function transformTapInventoryProduct(
   const imageUrl = extractImageUrl(product.image_url);
   const detailsUrl =
     stockNumber.length > 0
-      ? `${site.baseUrl}/search-inventory/?stock=${encodeURIComponent(stockNumber)}`
-      : `${site.baseUrl}/search-inventory/`;
+      ? `${site.inventoryPageUrl}?stock=${encodeURIComponent(stockNumber)}`
+      : site.inventoryPageUrl;
 
   return {
     vin,
@@ -60,8 +60,8 @@ export function transformTapInventoryProduct(
     row: product.vehicle_row.trim() || null,
     space: null,
     detailsUrl,
-    partsUrl: `${site.baseUrl}/parts-pricelist/`,
-    pricesUrl: `${site.baseUrl}/parts-pricelist/`,
+    partsUrl: `${new URL("/parts-pricelist/", site.inventoryPageUrl).toString()}`,
+    pricesUrl: `${new URL("/parts-pricelist/", site.inventoryPageUrl).toString()}`,
     engine: null,
     trim: null,
     transmission: null,

--- a/src/server/ingestion/tap-inventory-transform.ts
+++ b/src/server/ingestion/tap-inventory-transform.ts
@@ -60,6 +60,7 @@ export function transformTapInventoryProduct(
     row: product.vehicle_row.trim() || null,
     space: null,
     detailsUrl,
+    // The site exposes a single parts pricing page rather than separate parts/prices routes.
     partsUrl: `${new URL("/parts-pricelist/", site.inventoryPageUrl).toString()}`,
     pricesUrl: `${new URL("/parts-pricelist/", site.inventoryPageUrl).toString()}`,
     engine: null,

--- a/src/server/ingestion/types.ts
+++ b/src/server/ingestion/types.ts
@@ -4,7 +4,7 @@
  */
 export interface CanonicalVehicle {
   vin: string;
-  source: "pyp" | "row52" | "autorecycler" | "pullapart";
+  source: "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne";
   year: number;
   make: string;
   model: string;
@@ -39,7 +39,7 @@ export interface CanonicalVehicle {
  */
 export interface AlgoliaVehicleRecord {
   objectID: string;
-  source: "pyp" | "row52" | "autorecycler" | "pullapart";
+  source: "pyp" | "row52" | "autorecycler" | "pullapart" | "upullitne";
   year: number;
   make: string;
   model: string;

--- a/src/server/ingestion/types.ts
+++ b/src/server/ingestion/types.ts
@@ -4,7 +4,7 @@
  */
 export interface CanonicalVehicle {
   vin: string;
-  source: "pyp" | "row52" | "autorecycler";
+  source: "pyp" | "row52" | "autorecycler" | "pullapart";
   year: number;
   make: string;
   model: string;
@@ -39,7 +39,7 @@ export interface CanonicalVehicle {
  */
 export interface AlgoliaVehicleRecord {
   objectID: string;
-  source: "pyp" | "row52" | "autorecycler";
+  source: "pyp" | "row52" | "autorecycler" | "pullapart";
   year: number;
   make: string;
   model: string;

--- a/src/trigger/ingestion.ts
+++ b/src/trigger/ingestion.ts
@@ -32,6 +32,8 @@ async function executeIngestion(): Promise<IngestionRunResult> {
     totalUpserted: result.totalUpserted,
     totalDeleted: result.totalDeleted,
     pypCount: result.pypCount,
+    pullapartCount: result.pullapartCount,
+    upullitneCount: result.upullitneCount,
     row52Count: result.row52Count,
     autorecyclerCount: result.autorecyclerCount,
     durationMs: result.durationMs,

--- a/tests/ingestion/run-pipeline.smoke.test.ts
+++ b/tests/ingestion/run-pipeline.smoke.test.ts
@@ -11,10 +11,12 @@ describe("ingestion smoke", () => {
     expect(result.totalUpserted).toBeGreaterThanOrEqual(0);
     expect(result.totalDeleted).toBeGreaterThanOrEqual(0);
     expect(result.pypCount).toBeGreaterThanOrEqual(0);
+    expect(result.pullapartCount).toBeGreaterThanOrEqual(0);
     expect(result.row52Count).toBeGreaterThanOrEqual(0);
     expect(result.autorecyclerCount).toBeGreaterThanOrEqual(0);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.sourcesParallelMs).toBeGreaterThanOrEqual(0);
+    expect(result.timingsMs.pullapartFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.row52FetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.pypFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.autorecyclerFetchMs).toBeGreaterThanOrEqual(0);

--- a/tests/ingestion/run-pipeline.smoke.test.ts
+++ b/tests/ingestion/run-pipeline.smoke.test.ts
@@ -11,11 +11,13 @@ describe("ingestion smoke", () => {
     expect(result.totalUpserted).toBeGreaterThanOrEqual(0);
     expect(result.totalDeleted).toBeGreaterThanOrEqual(0);
     expect(result.pypCount).toBeGreaterThanOrEqual(0);
+    expect(result.upullitneCount).toBeGreaterThanOrEqual(0);
     expect(result.pullapartCount).toBeGreaterThanOrEqual(0);
     expect(result.row52Count).toBeGreaterThanOrEqual(0);
     expect(result.autorecyclerCount).toBeGreaterThanOrEqual(0);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.sourcesParallelMs).toBeGreaterThanOrEqual(0);
+    expect(result.timingsMs.upullitneFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.pullapartFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.row52FetchMs).toBeGreaterThanOrEqual(0);
     expect(result.timingsMs.pypFetchMs).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement a new `pullapart` vehicle source using the shared Pull-A-Part / U-Pull-&-Pay public APIs
- implement a new `upullitne` vehicle source for the TAP Inventory Search System plugin used by `upullitne.com`
- add both connectors to the ingestion pipeline, reconcile flow, status reporting, saved-search filters, Algolia/search mapping, ingestion scripts, and user-facing source labels/copy
- harden live decoding for real provider edge cases encountered during runtime validation and PR review
- optimize the `upullitne` TAP connector to use direct per-store full inventory dumps instead of slow store→make→model fanout

## Review follow-up fixes
- fix `run-pipeline.ts` source finalization so `upullitne` source runs are correctly recognized and finalized on failure paths
- keep missing-state advancement/deletion gating tied to the **core** sources (`row52`, `pyp`, `autorecycler`) so transient failures in supplemental hole-filling sources (`pullapart`, `upullitne`) do not unnecessarily freeze missing-state advancement
- fix Pull-A-Part region normalization to pass a missing abbreviation instead of duplicating the state name
- switch TAP bootstrap to dynamic nonce extraction from the inventory page instead of relying on a static hardcoded nonce
- move TAP search response decoding onto the Effect error channel instead of synchronous decode-only flow
- convert TAP `success: false` HTTP-200 responses into provider failures
- fail the TAP connector when no concrete stores are returned after filtering out the `Any` placeholder
- make TAP product decoding tolerant of live optional fields (`yard_in_date`, `hol_year`, `hol_mfr_code`, `hol_mfr_name`, `hol_model`)
- update TAP cross-store dedupe accounting so `vehiclesProcessed` only counts newly seen VINs across the connector run
- clarify that TAP `pricesUrl` intentionally aliases the same public parts/pricing page as `partsUrl`

## TAP / upullitne reverse engineering
- fetched the live inventory page and plugin bundle to recover the actual AJAX contract
- confirmed the plugin bootstraps with:
  - `sif_ajax_url = https://upullitne.com/wp-admin/admin-ajax.php`
  - `sif_ajax_nonce` embedded in `sif_ajax_object` on the rendered inventory page
- confirmed option endpoints:
  - `sif_get_stores`
  - `sif_get_makes`
  - `sif_update_models`
- confirmed `sif_search_products` requires the exact serialized form field names from the rendered page:
  - `sif_form_field_store`
  - `sif_form_field_make`
  - `sif_form_field_model`
  - `sorting[key]`, `sorting[state]`, `sorting[type]`
  - `sif_verify_request`
- deeper finding: this install supports a true **full-store dump**
  - `sif_search_products` with just `sif_form_field_store=<store>` plus sorting fields returns the store’s full inventory
  - omitting make/model behaves the same as explicit `Any/Any`
  - per-make fanout was unnecessary for this site

## Testing
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- `bun test src/server/ingestion/reconcile.test.ts src/server/ingestion/pipeline-policy.test.ts src/lib/__tests__/saved-search-filters.test.ts src/lib/__tests__/algolia-alert-search.test.ts tests/ingestion/run-pipeline.smoke.test.ts`
- Pull-A-Part live connector check:
  - `bun -e 'import { Effect } from "effect"; import { streamPullapartInventory } from "./src/server/ingestion/pullapart-connector"; const result = await Effect.runPromise(streamPullapartInventory({ onBatch: () => Effect.succeed(undefined), pagesPerChunk: 1000 })); console.log(JSON.stringify(result, null, 2));'`
  - completed successfully with `count: 43658`, `pagesProcessed: 1365`, `fullyExhausted: true`, `errors: []`
- TAP live connector check with dynamic nonce extraction and tolerant decoding:
  - `bun -e 'import { Effect } from "effect"; import { streamTapInventory } from "./src/server/ingestion/tap-inventory-connector"; const result = await Effect.runPromise(streamTapInventory({ onBatch: () => Effect.succeed(undefined), pagesPerChunk: 1000 })); console.log(JSON.stringify(result, null, 2));'`
  - completed successfully with:
    - `count: 2764`
    - `pagesProcessed: 4`
    - `fullyExhausted: true`
    - `errors: []`

## Notes
- Pull-A-Part yard coordinates are derived from normalized ZIP centroids because the public service payloads do not expose lat/lng.
- `upullitne` is modeled as a site-specific TAP source key rather than a generic `tap` family source for now, matching the current evidence and issue guidance.
- Source precedence now treats Pull-A-Part and U Pull-It Nebraska as lower-priority hole-filling sources after Row52 and PYP, ahead of AutoRecycler when those higher-priority sources are healthy.
- Trigger ingestion logging now includes both `pullapartCount` and `upullitneCount` so scheduled runs reflect the full pipeline output.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dcdab18-485b-4a28-8328-3eee5a9f42b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dcdab18-485b-4a28-8328-3eee5a9f42b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pull‑A‑Part and U Pull‑It Nebraska as searchable vehicle sources and included them across ingestion/status pipelines.
  * Search filters, saved searches, and sidebar source list now accept and display the new sources.
* **UI/Stats**
  * Site copy and SEO metadata updated; dashboard/stats now show five yard networks and per-source vehicle counts for the new sources.
* **Tests**
  * Test coverage expanded to include the new sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->