### PR TITLE
Enrich Pull-A-Part vehicle ingestion with extended details and images

### DIFF
--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -18,6 +18,12 @@ class PullapartNoDataError extends Data.TaggedError("PullapartNoDataError")<{
   }
 }
 
+export function isPullapartNoDataError(
+  error: unknown,
+): error is PullapartNoDataError {
+  return error instanceof PullapartNoDataError;
+}
+
 function isRetryablePullapartError(error: unknown): boolean {
   return (
     error instanceof RetryableHttpStatusError ||
@@ -287,10 +293,7 @@ export function fetchPullapartVehicleExtendedInfo(params: {
     schema: PullapartVehicleExtendedInfoSchema,
     notFoundIsNoData: true,
   }).pipe(
-    Effect.catchIf(
-      (error): error is PullapartNoDataError => error instanceof PullapartNoDataError,
-      () => Effect.succeed(null),
-    ),
+    Effect.catchIf(isPullapartNoDataError, () => Effect.succeed(null)),
   );
 }
 
@@ -316,10 +319,7 @@ export function fetchPullapartVehicleImage(params: {
       const webPath = response.webPath.trim();
       return webPath && webPath !== "Error retrieving image" ? webPath : null;
     }),
-    Effect.catchIf(
-      (error): error is PullapartNoDataError => error instanceof PullapartNoDataError,
-      () => Effect.succeed(null),
-    ),
+    Effect.catchIf(isPullapartNoDataError, () => Effect.succeed(null)),
   );
 }
 

--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -287,7 +287,10 @@ export function fetchPullapartVehicleExtendedInfo(params: {
     schema: PullapartVehicleExtendedInfoSchema,
     notFoundIsNoData: true,
   }).pipe(
-    Effect.catchTag("PullapartNoDataError", () => Effect.succeed(null)),
+    Effect.catchIf(
+      (error): error is PullapartNoDataError => error instanceof PullapartNoDataError,
+      () => Effect.succeed(null),
+    ),
   );
 }
 
@@ -313,7 +316,10 @@ export function fetchPullapartVehicleImage(params: {
       const webPath = response.webPath.trim();
       return webPath && webPath !== "Error retrieving image" ? webPath : null;
     }),
-    Effect.catchTag("PullapartNoDataError", () => Effect.succeed(null)),
+    Effect.catchIf(
+      (error): error is PullapartNoDataError => error instanceof PullapartNoDataError,
+      () => Effect.succeed(null),
+    ),
   );
 }
 

--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Schedule, Schema } from "effect";
+import { Data, Duration, Effect, Schedule, Schema } from "effect";
 import { API_ENDPOINTS } from "~/lib/constants";
 import {
   RequestTimeoutError,
@@ -9,6 +9,14 @@ const DEFAULT_RETRYABLE_STATUS_CODES = [429, 502, 503, 504] as const;
 const FETCH_TIMEOUT_MS = 30_000;
 const RETRY_LIMIT = 2;
 const RETRY_BASE_DELAY_MS = 1_000;
+
+class PullapartNoDataError extends Data.TaggedError("PullapartNoDataError")<{
+  context: string;
+}> {
+  override get message() {
+    return `${this.context} returned no data`;
+  }
+}
 
 function isRetryablePullapartError(error: unknown): boolean {
   return (
@@ -30,6 +38,7 @@ function pullapartJsonRequest<T, I, R>(params: {
   schema: Schema.Schema<T, I, R>;
   method?: "GET" | "POST";
   body?: string;
+  notFoundIsNoData?: boolean;
 }): Effect.Effect<T, Error, R> {
   const retrySchedule = buildRetrySchedule();
 
@@ -66,6 +75,12 @@ function pullapartJsonRequest<T, I, R>(params: {
           context: params.context,
           status: response.status,
         }),
+      );
+    }
+
+    if (response.status === 404 && params.notFoundIsNoData) {
+      return yield* Effect.fail(
+        new PullapartNoDataError({ context: params.context }),
       );
     }
 
@@ -265,12 +280,15 @@ export function fetchPullapartVehicleExtendedInfo(params: {
   locationId: number;
   ticketId: number;
   lineId: number;
-}): Effect.Effect<PullapartVehicleExtendedInfo, Error> {
+}): Effect.Effect<PullapartVehicleExtendedInfo | null, Error> {
   return pullapartJsonRequest({
     url: `${API_ENDPOINTS.PULLAPART_INVENTORY_BASE}/VehicleExtendedInfo/${params.locationId}/${params.ticketId}/${params.lineId}`,
     context: `Pull-A-Part vehicle extended info location=${params.locationId} ticket=${params.ticketId} line=${params.lineId}`,
     schema: PullapartVehicleExtendedInfoSchema,
-  });
+    notFoundIsNoData: true,
+  }).pipe(
+    Effect.catchTag("PullapartNoDataError", () => Effect.succeed(null)),
+  );
 }
 
 export function fetchPullapartVehicleImage(params: {
@@ -289,11 +307,13 @@ export function fetchPullapartVehicleImage(params: {
     url: url.toString(),
     context: `Pull-A-Part vehicle image location=${params.locationId} ticket=${params.ticketId} line=${params.lineId}`,
     schema: PullapartImageResponseSchema,
+    notFoundIsNoData: true,
   }).pipe(
     Effect.map((response: PullapartImageResponse) => {
       const webPath = response.webPath.trim();
       return webPath && webPath !== "Error retrieving image" ? webPath : null;
     }),
+    Effect.catchTag("PullapartNoDataError", () => Effect.succeed(null)),
   );
 }
 

--- a/src/server/ingestion/pullapart-client.ts
+++ b/src/server/ingestion/pullapart-client.ts
@@ -150,6 +150,39 @@ export const PullapartVehicleSchema = Schema.Struct({
 export type PullapartVehicle = Schema.Schema.Type<typeof PullapartVehicleSchema>;
 export type PullapartSearchVehicle = PullapartVehicle;
 
+export const PullapartVehicleExtendedInfoSchema = Schema.Struct({
+  trim: Schema.optional(Schema.NullOr(Schema.String)),
+  driveType: Schema.optional(Schema.NullOr(Schema.String)),
+  fuelType: Schema.optional(Schema.NullOr(Schema.String)),
+  engineBlock: Schema.optional(Schema.NullOr(Schema.String)),
+  engineCylinders: Schema.optional(
+    Schema.NullOr(Schema.Union(Schema.Number, Schema.String)),
+  ),
+  engineSize: Schema.optional(
+    Schema.NullOr(Schema.Union(Schema.Number, Schema.String)),
+  ),
+  engineAspiration: Schema.optional(Schema.NullOr(Schema.String)),
+  transType: Schema.optional(Schema.NullOr(Schema.String)),
+  transSpeeds: Schema.optional(
+    Schema.NullOr(Schema.Union(Schema.Number, Schema.String)),
+  ),
+  style: Schema.optional(Schema.NullOr(Schema.String)),
+  color: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export type PullapartVehicleExtendedInfo = Schema.Schema.Type<
+  typeof PullapartVehicleExtendedInfoSchema
+>;
+
+const PullapartImageResponseSchema = Schema.Struct({
+  webPath: Schema.String,
+  filePath: Schema.String,
+});
+
+type PullapartImageResponse = Schema.Schema.Type<
+  typeof PullapartImageResponseSchema
+>;
+
 export const PullapartVehicleSearchGroupSchema = Schema.Struct({
   locationID: Schema.Number,
   exact: Schema.Array(PullapartVehicleSchema),
@@ -227,6 +260,42 @@ export function searchPullapartVehicles(params: {
 }
 
 export const fetchPullapartVehiclesByMake = searchPullapartVehicles;
+
+export function fetchPullapartVehicleExtendedInfo(params: {
+  locationId: number;
+  ticketId: number;
+  lineId: number;
+}): Effect.Effect<PullapartVehicleExtendedInfo, Error> {
+  return pullapartJsonRequest({
+    url: `${API_ENDPOINTS.PULLAPART_INVENTORY_BASE}/VehicleExtendedInfo/${params.locationId}/${params.ticketId}/${params.lineId}`,
+    context: `Pull-A-Part vehicle extended info location=${params.locationId} ticket=${params.ticketId} line=${params.lineId}`,
+    schema: PullapartVehicleExtendedInfoSchema,
+  });
+}
+
+export function fetchPullapartVehicleImage(params: {
+  locationId: number;
+  ticketId: number;
+  lineId: number;
+}): Effect.Effect<string | null, Error> {
+  const url = new URL("https://imageservice.pullapart.com/img/retrieveimage/");
+  url.searchParams.set("locID", String(params.locationId));
+  url.searchParams.set("ticketID", String(params.ticketId));
+  url.searchParams.set("lineID", String(params.lineId));
+  url.searchParams.set("programID", "35");
+  url.searchParams.set("imageIndex", "1");
+
+  return pullapartJsonRequest({
+    url: url.toString(),
+    context: `Pull-A-Part vehicle image location=${params.locationId} ticket=${params.ticketId} line=${params.lineId}`,
+    schema: PullapartImageResponseSchema,
+  }).pipe(
+    Effect.map((response: PullapartImageResponse) => {
+      const webPath = response.webPath.trim();
+      return webPath && webPath !== "Error retrieving image" ? webPath : null;
+    }),
+  );
+}
 
 export function fetchZipGeo(
   zipCode: string,

--- a/src/server/ingestion/pullapart-connector.test.ts
+++ b/src/server/ingestion/pullapart-connector.test.ts
@@ -1,3 +1,4 @@
+import { FetchHttpClient } from "@effect/platform";
 import { afterEach, describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { streamPullapartInventory } from "./pullapart-connector";
@@ -96,7 +97,7 @@ function installPullapartFetchMock(options?: {
   detailResponse?: () => Response | Promise<Response>;
   imageResponse?: () => Response | Promise<Response>;
 }) {
-  globalThis.fetch = async (input) => {
+  globalThis.fetch = (async (input) => {
     const url =
       typeof input === "string"
         ? input
@@ -138,7 +139,7 @@ function installPullapartFetchMock(options?: {
     }
 
     throw new Error(`Unexpected fetch: ${url}`);
-  };
+  }) as typeof fetch;
 }
 
 afterEach(() => {
@@ -156,11 +157,7 @@ describe("streamPullapartInventory enrichment handling", () => {
           Effect.sync(() => {
             batches.push(vehicles);
           }),
-      }) as Effect.Effect<
-        Awaited<ReturnType<typeof streamPullapartInventory>>,
-        Error,
-        never
-      >,
+      }).pipe(Effect.provide(FetchHttpClient.layer)),
     );
 
     expect(result.errors).toEqual([]);
@@ -186,11 +183,7 @@ describe("streamPullapartInventory enrichment handling", () => {
           Effect.sync(() => {
             batches.push(vehicles);
           }),
-      }) as Effect.Effect<
-        Awaited<ReturnType<typeof streamPullapartInventory>>,
-        Error,
-        never
-      >,
+      }).pipe(Effect.provide(FetchHttpClient.layer)),
     );
 
     expect(result.count).toBe(0);

--- a/src/server/ingestion/pullapart-connector.test.ts
+++ b/src/server/ingestion/pullapart-connector.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { streamPullapartInventory } from "./pullapart-connector";
+import type { CanonicalVehicle } from "./types";
+
+const originalFetch = globalThis.fetch;
+
+const locationsResponse = [
+  {
+    idNumber: 3,
+    nameItem: "Atlanta South",
+    locationID: 3,
+    locationName: "Atlanta South",
+    address1: "1540 Henrico Road",
+    address2: "",
+    cityName: "Conley",
+    stateName: "GA",
+    zipCode: "30288",
+    siteTypeID: 3,
+    phone: "770-242-8844",
+    phoneCarBuying: "770-800-3118",
+    phoneUsedCar: "404-600-1307",
+    distanceInMiles: 0,
+    taxRate: 0.08,
+    warrantyDays: 32,
+    coreDays: 32,
+    allowsCashReturns: 0,
+    email: "Atlanta@pullapart.com",
+    passcodeForMiscItems: false,
+    retailEmail: "atl1Retail@pullapart.com",
+    environmentalFeeRate: 0.1,
+    environmentalFeeCap: 1000000,
+    locationShortName: "atl1",
+  },
+];
+
+const makesResponse = [
+  {
+    makeID: 6,
+    makeName: "ACURA",
+    rareFind: false,
+    dateModified: "2026-01-22T00:00:00Z",
+    dateCreated: "2026-01-22T00:00:00Z",
+  },
+];
+
+const vehicleSearchResponse = [
+  {
+    locationID: 3,
+    exact: [
+      {
+        vinID: 1236492,
+        ticketID: 1191613,
+        lineID: 12,
+        locID: 3,
+        locName: "Atlanta South",
+        makeID: 6,
+        makeName: "ACURA",
+        modelID: 10,
+        modelName: "MDX",
+        modelYear: 2006,
+        row: 304,
+        vin: "2HNYD18866H537719",
+        dateYardOn: "2026-01-22T12:46:20.98",
+        vinDecodedId: 13226,
+        extendedInfo: null,
+      },
+    ],
+    other: [],
+    inventory: null,
+  },
+];
+
+const zipGeoResponse = {
+  places: [
+    {
+      latitude: "33.6477",
+      longitude: "-84.3372",
+      "place name": "Conley",
+      state: "Georgia",
+      "state abbreviation": "GA",
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+function installPullapartFetchMock(options?: {
+  detailResponse?: () => Response | Promise<Response>;
+  imageResponse?: () => Response | Promise<Response>;
+}) {
+  globalThis.fetch = async (input) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    if (url.includes("/interchange/GetLocations")) {
+      return jsonResponse(locationsResponse);
+    }
+
+    if (url.includes("/Make/OnYard")) {
+      return jsonResponse(makesResponse);
+    }
+
+    if (url.includes("/Vehicle/Search")) {
+      return jsonResponse(vehicleSearchResponse);
+    }
+
+    if (url.includes("zippopotam.us")) {
+      return jsonResponse(zipGeoResponse);
+    }
+
+    if (url.includes("/VehicleExtendedInfo/")) {
+      return options?.detailResponse?.() ?? jsonResponse({}, 404);
+    }
+
+    if (url.includes("retrieveimage")) {
+      return (
+        options?.imageResponse?.() ??
+        jsonResponse(
+          {
+            webPath: "Error retrieving image",
+            filePath: "",
+          },
+          200,
+        )
+      );
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("streamPullapartInventory enrichment handling", () => {
+  test("keeps rows when enrichment endpoints return expected no-data responses", async () => {
+    installPullapartFetchMock();
+    const batches: CanonicalVehicle[][] = [];
+
+    const result = await Effect.runPromise(
+      streamPullapartInventory({
+        onBatch: (vehicles) =>
+          Effect.sync(() => {
+            batches.push(vehicles);
+          }),
+      }) as Effect.Effect<
+        Awaited<ReturnType<typeof streamPullapartInventory>>,
+        Error,
+        never
+      >,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.count).toBe(1);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0]?.[0]?.vin).toBe("2HNYD18866H537719");
+    expect(batches[0]?.[0]?.imageUrl).toBeNull();
+    expect(batches[0]?.[0]?.engine).toBeNull();
+    expect(batches[0]?.[0]?.trim).toBeNull();
+    expect(batches[0]?.[0]?.transmission).toBeNull();
+  });
+
+  test("skips rows and records errors when enrichment transport fails", async () => {
+    installPullapartFetchMock({
+      detailResponse: () => jsonResponse({ message: "upstream error" }, 500),
+    });
+    const batches: CanonicalVehicle[][] = [];
+
+    const result = await Effect.runPromise(
+      streamPullapartInventory({
+        onBatch: (vehicles) =>
+          Effect.sync(() => {
+            batches.push(vehicles);
+          }),
+      }) as Effect.Effect<
+        Awaited<ReturnType<typeof streamPullapartInventory>>,
+        Error,
+        never
+      >,
+    );
+
+    expect(result.count).toBe(0);
+    expect(batches).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Vehicle enrichment failed");
+    expect(result.errors[0]).toContain("loc=3");
+    expect(result.errors[0]).toContain("ticket=1191613");
+    expect(result.errors[0]).toContain("line=12");
+    expect(result.errors[0]).toContain("API error: 500");
+  });
+});

--- a/src/server/ingestion/pullapart-connector.ts
+++ b/src/server/ingestion/pullapart-connector.ts
@@ -1,6 +1,8 @@
 import { HttpClient } from "@effect/platform";
 import { Effect } from "effect";
 import {
+  fetchPullapartVehicleExtendedInfo,
+  fetchPullapartVehicleImage,
   fetchZipGeo,
   fetchPullapartLocations,
   fetchPullapartMakesOnYard,
@@ -10,6 +12,8 @@ import { DEFAULT_INGESTION_PROGRESS_PAGE_INTERVAL } from "./constants";
 import { PullapartProviderError } from "./errors";
 import { transformPullapartVehicle } from "./pullapart-transform";
 import type { CanonicalVehicle } from "./types";
+
+const VEHICLE_ENRICH_CONCURRENCY = 8;
 
 export interface PullapartStreamResult {
   source: "pullapart";
@@ -149,14 +153,58 @@ export function streamPullapartInventory<E, R>(options: {
           geoByZip.set(location.zipCode, geo);
         }
 
-        const uniqueByVin = new Map<string, CanonicalVehicle>();
+        const uniqueRowsByVin = new Map<string, (typeof rows)[number]>();
         for (const row of rows) {
-          const transformed = transformPullapartVehicle(row, location, geo);
-          if (!transformed) continue;
-          uniqueByVin.set(transformed.vin, transformed);
+          const vin = row.vin?.trim();
+          if (!vin || uniqueRowsByVin.has(vin)) continue;
+          uniqueRowsByVin.set(vin, row);
         }
 
-        const batch = [...uniqueByVin.values()];
+        const enriched = yield* Effect.all(
+          [...uniqueRowsByVin.values()].map((row) =>
+            Effect.gen(function* () {
+              const detail = yield* fetchPullapartVehicleExtendedInfo({
+                locationId: row.locID,
+                ticketId: row.ticketID,
+                lineId: row.lineID,
+              }).pipe(
+                Effect.catchAll((error) =>
+                  Effect.gen(function* () {
+                    yield* Effect.logWarning(
+                      `[Pull-A-Part] VehicleExtendedInfo failed loc=${row.locID} ticket=${row.ticketID} line=${row.lineID}: ${error.message}`,
+                    );
+                    return null;
+                  }),
+                ),
+              );
+
+              const imageUrl = yield* fetchPullapartVehicleImage({
+                locationId: row.locID,
+                ticketId: row.ticketID,
+                lineId: row.lineID,
+              }).pipe(
+                Effect.catchAll((error) =>
+                  Effect.gen(function* () {
+                    yield* Effect.logWarning(
+                      `[Pull-A-Part] image fetch failed loc=${row.locID} ticket=${row.ticketID} line=${row.lineID}: ${error.message}`,
+                    );
+                    return null;
+                  }),
+                ),
+              );
+
+              return transformPullapartVehicle(row, location, geo, {
+                detail,
+                imageUrl,
+              });
+            }),
+          ),
+          { concurrency: VEHICLE_ENRICH_CONCURRENCY },
+        );
+
+        const batch = enriched.filter(
+          (vehicle): vehicle is CanonicalVehicle => vehicle !== null,
+        );
         if (batch.length > 0) {
           yield* options.onBatch(batch);
         }

--- a/src/server/ingestion/pullapart-connector.ts
+++ b/src/server/ingestion/pullapart-connector.ts
@@ -167,37 +167,28 @@ export function streamPullapartInventory<E, R>(options: {
                 locationId: row.locID,
                 ticketId: row.ticketID,
                 lineId: row.lineID,
-              }).pipe(
-                Effect.catchAll((error) =>
-                  Effect.gen(function* () {
-                    yield* Effect.logWarning(
-                      `[Pull-A-Part] VehicleExtendedInfo failed loc=${row.locID} ticket=${row.ticketID} line=${row.lineID}: ${error.message}`,
-                    );
-                    return null;
-                  }),
-                ),
-              );
+              });
 
               const imageUrl = yield* fetchPullapartVehicleImage({
                 locationId: row.locID,
                 ticketId: row.ticketID,
                 lineId: row.lineID,
-              }).pipe(
-                Effect.catchAll((error) =>
-                  Effect.gen(function* () {
-                    yield* Effect.logWarning(
-                      `[Pull-A-Part] image fetch failed loc=${row.locID} ticket=${row.ticketID} line=${row.lineID}: ${error.message}`,
-                    );
-                    return null;
-                  }),
-                ),
-              );
+              });
 
               return transformPullapartVehicle(row, location, geo, {
                 detail,
                 imageUrl,
               });
-            }),
+            }).pipe(
+              Effect.catchAll((error) =>
+                Effect.gen(function* () {
+                  const message = `[Pull-A-Part] Vehicle enrichment failed loc=${row.locID} ticket=${row.ticketID} line=${row.lineID}: ${error.message}`;
+                  yield* Effect.logWarning(message);
+                  errors.push(message);
+                  return null;
+                }),
+              ),
+            ),
           ),
           { concurrency: VEHICLE_ENRICH_CONCURRENCY },
         );

--- a/src/server/ingestion/pullapart-transform.test.ts
+++ b/src/server/ingestion/pullapart-transform.test.ts
@@ -116,4 +116,51 @@ describe("transformPullapartVehicle", () => {
     expect(result?.trim).toBe("Base");
     expect(result?.transmission).toBe("Automatic");
   });
+
+  test("prefers structured detail values over extendedInfo fallbacks", () => {
+    const result = transformPullapartVehicle(
+      {
+        ...vehicle,
+        extendedInfo: {
+          engineDescription: "Legacy engine",
+          transmissionDescription: "Legacy transmission",
+        },
+      },
+      location,
+      geo,
+      {
+        detail: {
+          trim: null,
+          driveType: null,
+          fuelType: null,
+          engineBlock: "V",
+          engineCylinders: 6,
+          engineSize: 3.7,
+          engineAspiration: "Turbo",
+          transType: "A",
+          transSpeeds: 6,
+          style: null,
+          color: null,
+        },
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.engine).toBe("3.7L V6 Turbo");
+    expect(result?.transmission).toBe("6-Speed Automatic");
+  });
+
+  test("returns null for invalid dateOnlyMatch values", () => {
+    const result = transformPullapartVehicle(
+      {
+        ...vehicle,
+        dateYardOn: "2026-02-31",
+      },
+      location,
+      geo,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.availableDate).toBeNull();
+  });
 });

--- a/src/server/ingestion/pullapart-transform.test.ts
+++ b/src/server/ingestion/pullapart-transform.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  PullapartLocation,
+  PullapartVehicle,
+  PullapartVehicleExtendedInfo,
+  PullapartZipGeo,
+} from "./pullapart-client";
+import { transformPullapartVehicle } from "./pullapart-transform";
+
+const location: PullapartLocation = {
+  idNumber: 3,
+  nameItem: "Atlanta South",
+  locationID: 3,
+  locationName: "Atlanta South",
+  address1: "1540 Henrico Road",
+  address2: "",
+  cityName: "Conley",
+  stateName: "GA",
+  zipCode: "30288",
+  siteTypeID: 3,
+  phone: "770-242-8844",
+  phoneCarBuying: "770-800-3118",
+  phoneUsedCar: "404-600-1307",
+  distanceInMiles: 0,
+  taxRate: 0.08,
+  warrantyDays: 32,
+  coreDays: 32,
+  allowsCashReturns: 0,
+  email: "Atlanta@pullapart.com",
+  passcodeForMiscItems: false,
+  retailEmail: "atl1Retail@pullapart.com",
+  environmentalFeeRate: 0.1,
+  environmentalFeeCap: 1000000,
+  locationShortName: "atl1",
+};
+
+const geo: PullapartZipGeo = {
+  lat: 33.6477,
+  lng: -84.3372,
+};
+
+const vehicle: PullapartVehicle = {
+  vinID: 1236492,
+  ticketID: 1191613,
+  lineID: 12,
+  locID: 3,
+  locName: "Atlanta South",
+  makeID: 6,
+  makeName: "ACURA",
+  modelID: 10,
+  modelName: "MDX",
+  modelYear: 2006,
+  row: 304,
+  vin: "2HNYD18866H537719",
+  dateYardOn: "2026-01-22T12:46:20.98",
+  vinDecodedId: 13226,
+  extendedInfo: null,
+};
+
+describe("transformPullapartVehicle", () => {
+  test("uses detail and image enrichment for canonical fields", () => {
+    const detail: PullapartVehicleExtendedInfo = {
+      trim: "Touring w/Navi",
+      driveType: "AWD",
+      fuelType: "G",
+      engineBlock: "V",
+      engineCylinders: 6,
+      engineSize: 3.5,
+      engineAspiration: "N/A",
+      transType: "A",
+      transSpeeds: 5,
+      style: "AWD Touring 4dr SUV w/Navi",
+      color: "BLACK",
+    };
+
+    const result = transformPullapartVehicle(vehicle, location, geo, {
+      detail,
+      imageUrl:
+        "https://papimages.blob.core.windows.net/carinventory/3/2026/01/20260122131716_3_1191613_12.png",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.color).toBe("Black");
+    expect(result?.imageUrl).toBe(
+      "https://papimages.blob.core.windows.net/carinventory/3/2026/01/20260122131716_3_1191613_12.png",
+    );
+    expect(result?.availableDate).toBe("2026-01-22T00:00:00.000Z");
+    expect(result?.locationName).toBe("Atlanta South");
+    expect(result?.locationCity).toBe("Conley");
+    expect(result?.state).toBe("Georgia");
+    expect(result?.stateAbbr).toBe("GA");
+    expect(result?.row).toBe("304");
+    expect(result?.trim).toBe("Touring w/Navi");
+    expect(result?.engine).toBe("3.5L V6");
+    expect(result?.transmission).toBe("5-Speed Automatic");
+  });
+
+  test("falls back to extendedInfo and returns null for invalid dates", () => {
+    const result = transformPullapartVehicle(
+      {
+        ...vehicle,
+        dateYardOn: "not-a-date",
+        extendedInfo: {
+          color: "silver",
+          trim: "Base",
+          transmissionDescription: "Automatic",
+        },
+      },
+      location,
+      geo,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.availableDate).toBeNull();
+    expect(result?.color).toBe("Silver");
+    expect(result?.trim).toBe("Base");
+    expect(result?.transmission).toBe("Automatic");
+  });
+});

--- a/src/server/ingestion/pullapart-transform.ts
+++ b/src/server/ingestion/pullapart-transform.ts
@@ -7,6 +7,7 @@ import {
 import type {
   PullapartLocation,
   PullapartVehicle,
+  PullapartVehicleExtendedInfo,
   PullapartZipGeo,
 } from "./pullapart-client";
 import type { CanonicalVehicle } from "./types";
@@ -49,10 +50,106 @@ function buildDetailsUrl(
   return `${baseHost}/inventory/search/?${query.toString()}#results`;
 }
 
+function readDetailString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readDetailNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function formatPullapartEngine(
+  detail: PullapartVehicleExtendedInfo | null,
+  extendedInfo: unknown,
+): string | null {
+  const fallback = readExtendedInfoField(extendedInfo, [
+    "engine",
+    "engineDescription",
+  ]);
+  if (fallback) return fallback;
+  if (!detail) return null;
+
+  const size = readDetailNumber(detail.engineSize);
+  const block = readDetailString(detail.engineBlock);
+  const cylinders = readDetailNumber(detail.engineCylinders);
+  const aspiration = readDetailString(detail.engineAspiration);
+
+  const family =
+    block && cylinders !== null
+      ? `${block}${Math.trunc(cylinders)}`
+      : block ?? (cylinders !== null ? String(Math.trunc(cylinders)) : null);
+  const parts = [
+    size !== null ? `${size}L` : null,
+    family,
+    aspiration && aspiration !== "N/A" ? aspiration : null,
+  ].filter((part): part is string => Boolean(part));
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+function formatPullapartTransmission(
+  detail: PullapartVehicleExtendedInfo | null,
+  extendedInfo: unknown,
+): string | null {
+  const fallback = readExtendedInfoField(extendedInfo, [
+    "transmission",
+    "transmissionDescription",
+  ]);
+  if (fallback) return fallback;
+  if (!detail) return null;
+
+  const speeds = readDetailNumber(detail.transSpeeds);
+  const transType = readDetailString(detail.transType);
+  const transTypeLabel =
+    transType === "A"
+      ? "Automatic"
+      : transType === "M"
+        ? "Manual"
+        : transType === "CVT"
+          ? "CVT"
+          : transType;
+
+  if (speeds !== null && transTypeLabel) {
+    return `${Math.trunc(speeds)}-Speed ${transTypeLabel}`;
+  }
+
+  return transTypeLabel ?? null;
+}
+
+function normalizePullapartAvailableDate(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const dateOnlyMatch = /^(\d{4}-\d{2}-\d{2})/.exec(trimmed);
+  if (dateOnlyMatch?.[1]) {
+    return `${dateOnlyMatch[1]}T00:00:00.000Z`;
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
 export function transformPullapartVehicle(
   vehicle: PullapartVehicle,
   location: PullapartLocation | undefined,
   geo: PullapartZipGeo | undefined,
+  options?: {
+    detail?: PullapartVehicleExtendedInfo | null;
+    imageUrl?: string | null;
+  },
 ): CanonicalVehicle | null {
   if (!location) return null;
   if (!geo) return null;
@@ -60,6 +157,9 @@ export function transformPullapartVehicle(
   if (!vehicle.makeName?.trim() || !vehicle.modelName?.trim()) return null;
 
   const region = normalizeRegion(location.stateName, null);
+  const detail = options?.detail ?? null;
+  const locationName = location.locationName.trim() || vehicle.locName.trim();
+  const locationCity = location.cityName.trim() || "Unknown";
 
   return {
     vin: vehicle.vin.trim(),
@@ -68,14 +168,15 @@ export function transformPullapartVehicle(
     make: normalizeCanonicalMake(vehicle.makeName),
     model: vehicle.modelName.trim(),
     color: normalizeCanonicalColor(
-      readExtendedInfoField(vehicle.extendedInfo, ["color", "exteriorColor"]),
+      readDetailString(detail?.color) ??
+        readExtendedInfoField(vehicle.extendedInfo, ["color", "exteriorColor"]),
     ),
     stockNumber: String(vehicle.ticketID),
-    imageUrl: null,
-    availableDate: vehicle.dateYardOn || null,
+    imageUrl: options?.imageUrl ?? null,
+    availableDate: normalizePullapartAvailableDate(vehicle.dateYardOn),
     locationCode: String(location.locationID),
-    locationName: location.locationName.trim(),
-    locationCity: location.cityName.trim() || "Unknown",
+    locationName,
+    locationCity,
     state: region.state,
     stateAbbr: region.stateAbbr,
     lat: geo.lat,
@@ -89,14 +190,10 @@ export function transformPullapartVehicle(
     detailsUrl: buildDetailsUrl(location, vehicle),
     partsUrl: null,
     pricesUrl: null,
-    engine: readExtendedInfoField(vehicle.extendedInfo, [
-      "engine",
-      "engineDescription",
-    ]),
-    trim: readExtendedInfoField(vehicle.extendedInfo, ["trim"]),
-    transmission: readExtendedInfoField(vehicle.extendedInfo, [
-      "transmission",
-      "transmissionDescription",
-    ]),
+    engine: formatPullapartEngine(detail, vehicle.extendedInfo),
+    trim:
+      readDetailString(detail?.trim) ??
+      readExtendedInfoField(vehicle.extendedInfo, ["trim"]),
+    transmission: formatPullapartTransmission(detail, vehicle.extendedInfo),
   };
 }

--- a/src/server/ingestion/pullapart-transform.ts
+++ b/src/server/ingestion/pullapart-transform.ts
@@ -75,58 +75,59 @@ function formatPullapartEngine(
   detail: PullapartVehicleExtendedInfo | null,
   extendedInfo: unknown,
 ): string | null {
-  const fallback = readExtendedInfoField(extendedInfo, [
-    "engine",
-    "engineDescription",
-  ]);
-  if (fallback) return fallback;
-  if (!detail) return null;
+  if (detail) {
+    const size = readDetailNumber(detail.engineSize);
+    const block = readDetailString(detail.engineBlock);
+    const cylinders = readDetailNumber(detail.engineCylinders);
+    const aspiration = readDetailString(detail.engineAspiration);
 
-  const size = readDetailNumber(detail.engineSize);
-  const block = readDetailString(detail.engineBlock);
-  const cylinders = readDetailNumber(detail.engineCylinders);
-  const aspiration = readDetailString(detail.engineAspiration);
+    const family =
+      block && cylinders !== null
+        ? `${block}${Math.trunc(cylinders)}`
+        : block ?? (cylinders !== null ? String(Math.trunc(cylinders)) : null);
+    const detailParts = [
+      size !== null ? `${size}L` : null,
+      family,
+      aspiration && aspiration !== "N/A" ? aspiration : null,
+    ].filter((part): part is string => Boolean(part));
 
-  const family =
-    block && cylinders !== null
-      ? `${block}${Math.trunc(cylinders)}`
-      : block ?? (cylinders !== null ? String(Math.trunc(cylinders)) : null);
-  const parts = [
-    size !== null ? `${size}L` : null,
-    family,
-    aspiration && aspiration !== "N/A" ? aspiration : null,
-  ].filter((part): part is string => Boolean(part));
+    if (detailParts.length > 0) {
+      return detailParts.join(" ");
+    }
+  }
 
-  return parts.length > 0 ? parts.join(" ") : null;
+  return readExtendedInfoField(extendedInfo, ["engine", "engineDescription"]);
 }
 
 function formatPullapartTransmission(
   detail: PullapartVehicleExtendedInfo | null,
   extendedInfo: unknown,
 ): string | null {
-  const fallback = readExtendedInfoField(extendedInfo, [
+  if (detail) {
+    const speeds = readDetailNumber(detail.transSpeeds);
+    const transType = readDetailString(detail.transType);
+    const transTypeLabel =
+      transType === "A"
+        ? "Automatic"
+        : transType === "M"
+          ? "Manual"
+          : transType === "CVT"
+            ? "CVT"
+            : transType;
+
+    if (speeds !== null && transTypeLabel) {
+      return `${Math.trunc(speeds)}-Speed ${transTypeLabel}`;
+    }
+
+    if (transTypeLabel) {
+      return transTypeLabel;
+    }
+  }
+
+  return readExtendedInfoField(extendedInfo, [
     "transmission",
     "transmissionDescription",
   ]);
-  if (fallback) return fallback;
-  if (!detail) return null;
-
-  const speeds = readDetailNumber(detail.transSpeeds);
-  const transType = readDetailString(detail.transType);
-  const transTypeLabel =
-    transType === "A"
-      ? "Automatic"
-      : transType === "M"
-        ? "Manual"
-        : transType === "CVT"
-          ? "CVT"
-          : transType;
-
-  if (speeds !== null && transTypeLabel) {
-    return `${Math.trunc(speeds)}-Speed ${transTypeLabel}`;
-  }
-
-  return transTypeLabel ?? null;
 }
 
 function normalizePullapartAvailableDate(value: string | null): string | null {
@@ -135,7 +136,12 @@ function normalizePullapartAvailableDate(value: string | null): string | null {
 
   const dateOnlyMatch = /^(\d{4}-\d{2}-\d{2})/.exec(trimmed);
   if (dateOnlyMatch?.[1]) {
-    return `${dateOnlyMatch[1]}T00:00:00.000Z`;
+    const isoCandidate = `${dateOnlyMatch[1]}T00:00:00.000Z`;
+    const parsed = new Date(isoCandidate);
+    return Number.isNaN(parsed.getTime()) ||
+        parsed.toISOString().slice(0, 10) !== dateOnlyMatch[1]
+      ? null
+      : parsed.toISOString();
   }
 
   const parsed = new Date(trimmed);


### PR DESCRIPTION
## Summary
- Enriches Pull-A-Part inventory ingestion with per-vehicle extended info and image lookups.
- Updates canonical transform logic to derive engine, transmission, trim, color, image URL, and normalized available dates from richer source data.
- Adds concurrency-limited enrichment in the connector and skips duplicate VINs before fetching details.
- Adds unit coverage for enrichment-driven fields and date fallback behavior.

## Testing
- `bun test src/server/ingestion/pullapart-transform.test.ts`
- Not run: full `bun run check`
- Not run: integration verification against live Pull-A-Part endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enriched vehicle ingestion now fetches extended vehicle details and images; missing or "no data" responses are treated as null.

* **Refactor**
  * Improved deduplication and concurrent enrichment with controlled concurrency, safer fallback logic, and standardized parsing/normalization for color, trim, engine/transmission, and available dates.
  * Enrichment failures are logged and mapped to null; batches only include successfully enriched vehicles.

* **Tests**
  * Added tests covering enrichment, fallbacks, precedence, error reporting, and date edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->