### PR TITLE
Allow global saved-search filter bounds

### DIFF
--- a/src/components/search/MorphingFilterBar.tsx
+++ b/src/components/search/MorphingFilterBar.tsx
@@ -30,8 +30,8 @@ interface MorphingFilterBarProps {
     states: string[];
     salvageYards: string[];
     sources?: string[];
-    minYear: number;
-    maxYear: number;
+    minYear?: number;
+    maxYear?: number;
     sortBy: string;
   };
   autoOpenSaveDialog?: boolean;

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -70,7 +70,7 @@ import {
   type StoredLocationPreference,
 } from "~/lib/location-preferences";
 import {
-  MAX_VEHICLE_YEAR,
+  getMaxVehicleYear,
   mergeSelectedFilterOptions,
   MIN_VEHICLE_YEAR,
   normalizeVehicleYearFilter,
@@ -685,20 +685,20 @@ function AlgoliaSearchInner({
     ],
   );
 
-  const parsedRouteYears = (yearRangeState.year ?? "")
-    .split(":")
-    .map((value) => {
-      const parsed = Number.parseInt(value, 10);
-      return Number.isFinite(parsed) ? parsed : null;
-    });
-  const rawRouteMinYear = parsedRouteYears[0] ?? null;
-  const rawRouteMaxYear = parsedRouteYears[1] ?? null;
-  const normalizedRouteYearFilter = normalizeVehicleYearFilter(
-    rawRouteMinYear,
-    rawRouteMaxYear,
-  );
+  const normalizedRouteYearFilter = useMemo(() => {
+    const parsedRouteYears = (yearRangeState.year ?? "")
+      .split(":")
+      .map((value) => {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? parsed : null;
+      });
+    const rawRouteMinYear = parsedRouteYears[0] ?? null;
+    const rawRouteMaxYear = parsedRouteYears[1] ?? null;
+
+    return normalizeVehicleYearFilter(rawRouteMinYear, rawRouteMaxYear);
+  }, [yearRangeState.year]);
   const yearMin = MIN_VEHICLE_YEAR;
-  const yearMax = MAX_VEHICLE_YEAR;
+  const yearMax = getMaxVehicleYear();
   const yearRange = normalizedRouteYearFilter.range;
   const isYearFiltered = normalizedRouteYearFilter.isFiltered;
 

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -1020,9 +1020,30 @@ function AlgoliaSearchInner({
 
   const handleYearRangeChange = useCallback(
     (range: [number, number]) => {
-      refineYear(range);
+      const normalizedRange = normalizeVehicleYearFilter(range[0], range[1]);
+
+      setIndexUiState((prev) => {
+        const nextRangeState = {
+          ...((prev.range ?? {}) as Record<string, string>),
+        };
+
+        if (
+          normalizedRange.minYear === undefined &&
+          normalizedRange.maxYear === undefined
+        ) {
+          delete nextRangeState.year;
+        } else {
+          nextRangeState.year = `${normalizedRange.minYear ?? ""}:${normalizedRange.maxYear ?? ""}`;
+        }
+
+        return {
+          ...prev,
+          range:
+            Object.keys(nextRangeState).length > 0 ? nextRangeState : undefined,
+        };
+      });
     },
-    [refineYear],
+    [setIndexUiState],
   );
 
   // Track search outcomes (skip errors so failed queries can be re-tracked on success)

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -69,6 +69,12 @@ import {
   parseStoredLocationPreference,
   type StoredLocationPreference,
 } from "~/lib/location-preferences";
+import {
+  MAX_VEHICLE_YEAR,
+  mergeSelectedFilterOptions,
+  MIN_VEHICLE_YEAR,
+  normalizeVehicleYearFilter,
+} from "~/lib/search-filter-bounds";
 import { algoliaHitToSearchVehicle } from "~/lib/search-vehicles";
 import { cn } from "~/lib/utils";
 import type { DataSource, SearchResult as SearchResultType } from "~/lib/types";
@@ -112,17 +118,6 @@ const ALLOWED_SOURCES: DataSource[] = [
   "pullapart",
   "upullitne",
 ];
-
-function clampRouteYear(
-  value: number | null,
-  min: number,
-  max: number,
-): number | null {
-  if (value === null || !Number.isFinite(value) || value <= 0) {
-    return null;
-  }
-  return Math.min(max, Math.max(min, value));
-}
 
 function sanitizeSources(values: unknown): DataSource[] {
   if (!Array.isArray(values)) return [];
@@ -324,7 +319,6 @@ function AlgoliaSearchInner({
   isLoggedIn,
   userLocation: _userLocation,
 }: SearchPageContentProps) {
-  const currentYear = new Date().getFullYear();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
@@ -474,11 +468,7 @@ function AlgoliaSearchInner({
   });
 
   // Year range
-  const {
-    range: yearBounds,
-    start: yearStart,
-    refine: refineYear,
-  } = useRange({
+  const { refine: refineYear } = useRange({
     attribute: "year",
   });
 
@@ -643,16 +633,6 @@ function AlgoliaSearchInner({
     [hits, resolvedUserLocation],
   );
 
-  const filterOptions = useMemo(
-    () => ({
-      makes: makeItems.map((i) => i.value).sort(),
-      colors: colorItems.map((i) => i.value).sort(),
-      states: stateItems.map((i) => i.value).sort(),
-      salvageYards: locationItems.map((i) => i.value).sort(),
-    }),
-    [makeItems, colorItems, stateItems, locationItems],
-  );
-
   // Selected filters
   const selectedMakes = useMemo(
     () => refinementList.make ?? [],
@@ -674,6 +654,36 @@ function AlgoliaSearchInner({
     () => sanitizeSources(refinementList.source ?? []),
     [refinementList],
   );
+  const filterOptions = useMemo(
+    () => ({
+      makes: mergeSelectedFilterOptions(
+        makeItems.map((item) => item.value),
+        selectedMakes,
+      ),
+      colors: mergeSelectedFilterOptions(
+        colorItems.map((item) => item.value),
+        selectedColors,
+      ),
+      states: mergeSelectedFilterOptions(
+        stateItems.map((item) => item.value),
+        selectedStates,
+      ),
+      salvageYards: mergeSelectedFilterOptions(
+        locationItems.map((item) => item.value),
+        selectedLocations,
+      ),
+    }),
+    [
+      colorItems,
+      locationItems,
+      makeItems,
+      selectedColors,
+      selectedLocations,
+      selectedMakes,
+      selectedStates,
+      stateItems,
+    ],
+  );
 
   const parsedRouteYears = (yearRangeState.year ?? "")
     .split(":")
@@ -683,45 +693,14 @@ function AlgoliaSearchInner({
     });
   const rawRouteMinYear = parsedRouteYears[0] ?? null;
   const rawRouteMaxYear = parsedRouteYears[1] ?? null;
-
-  const yearMin: number =
-    typeof yearBounds.min === "number" &&
-    Number.isFinite(yearBounds.min) &&
-    yearBounds.min > 0
-      ? yearBounds.min
-      : 1900;
-  const yearMax: number =
-    typeof yearBounds.max === "number" &&
-    Number.isFinite(yearBounds.max) &&
-    yearBounds.max > 0
-      ? yearBounds.max
-      : currentYear;
-  let routeMinYear = clampRouteYear(rawRouteMinYear, yearMin, yearMax);
-  let routeMaxYear = clampRouteYear(rawRouteMaxYear, yearMin, yearMax);
-  if (
-    routeMinYear !== null &&
-    routeMaxYear !== null &&
-    routeMinYear > routeMaxYear
-  ) {
-    [routeMinYear, routeMaxYear] = [routeMaxYear, routeMinYear];
-  }
-  const yearRange: [number, number] = [
-    routeMinYear ??
-      clampRouteYear(
-        Number.isFinite(yearStart[0]) ? (yearStart[0] as number) : yearMin,
-        yearMin,
-        yearMax,
-      ) ??
-      yearMin,
-    routeMaxYear ??
-      clampRouteYear(
-        Number.isFinite(yearStart[1]) ? (yearStart[1] as number) : yearMax,
-        yearMin,
-        yearMax,
-      ) ??
-      yearMax,
-  ];
-  const isYearFiltered = yearRange[0] !== yearMin || yearRange[1] !== yearMax;
+  const normalizedRouteYearFilter = normalizeVehicleYearFilter(
+    rawRouteMinYear,
+    rawRouteMaxYear,
+  );
+  const yearMin = MIN_VEHICLE_YEAR;
+  const yearMax = MAX_VEHICLE_YEAR;
+  const yearRange = normalizedRouteYearFilter.range;
+  const isYearFiltered = normalizedRouteYearFilter.isFiltered;
 
   const activeFilterCount =
     selectedMakes.length +
@@ -738,17 +717,18 @@ function AlgoliaSearchInner({
       states: selectedStates,
       salvageYards: selectedLocations,
       sources: selectedSources,
-      minYear: yearRange[0],
-      maxYear: yearRange[1],
+      minYear: normalizedRouteYearFilter.minYear,
+      maxYear: normalizedRouteYearFilter.maxYear,
       sortBy,
     }),
     [
+      normalizedRouteYearFilter.maxYear,
+      normalizedRouteYearFilter.minYear,
       selectedMakes,
       selectedColors,
       selectedStates,
       selectedLocations,
       selectedSources,
-      yearRange,
       sortBy,
     ],
   );

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -7,6 +7,10 @@ import {
 } from "~/components/ui/collapsible";
 import { Label } from "~/components/ui/label";
 import { Slider } from "~/components/ui/slider";
+import {
+  MAX_VEHICLE_YEAR,
+  MIN_VEHICLE_YEAR,
+} from "~/lib/search-filter-bounds";
 import type { DataSource } from "~/lib/types";
 
 interface FilterOptions {
@@ -164,8 +168,8 @@ export function SidebarContent({
                 const [min, max] = value as [number, number];
                 onYearRangeChange([min, max]);
               }}
-              min={yearRangeLimits?.min ?? 1900}
-              max={yearRangeLimits?.max ?? new Date().getFullYear()}
+              min={yearRangeLimits?.min ?? MIN_VEHICLE_YEAR}
+              max={yearRangeLimits?.max ?? MAX_VEHICLE_YEAR}
               step={1}
               className="w-full"
               onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -122,7 +122,7 @@ export function SidebarContent({
         </CollapsibleContent>
       </Collapsible>
 
-      {filterOptions.makes.length > 1 && (
+      {filterOptions.makes.length > 0 && (
         <Collapsible defaultOpen>
           <CollapsibleTrigger className="hover:bg-accent flex w-full items-center justify-between rounded p-2">
             <span className="font-medium">Make</span>

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -8,7 +8,7 @@ import {
 import { Label } from "~/components/ui/label";
 import { Slider } from "~/components/ui/slider";
 import {
-  MAX_VEHICLE_YEAR,
+  getMaxVehicleYear,
   MIN_VEHICLE_YEAR,
 } from "~/lib/search-filter-bounds";
 import type { DataSource } from "~/lib/types";
@@ -169,7 +169,7 @@ export function SidebarContent({
                 onYearRangeChange([min, max]);
               }}
               min={yearRangeLimits?.min ?? MIN_VEHICLE_YEAR}
-              max={yearRangeLimits?.max ?? MAX_VEHICLE_YEAR}
+              max={yearRangeLimits?.max ?? getMaxVehicleYear()}
               step={1}
               className="w-full"
               onPointerDown={(e) => e.stopPropagation()}

--- a/src/lib/__tests__/algolia-alert-search.test.ts
+++ b/src/lib/__tests__/algolia-alert-search.test.ts
@@ -5,6 +5,7 @@ import {
   getAlertMatchStats,
 } from "~/lib/algolia-alert-search";
 import { searchClient } from "~/lib/algolia-search";
+import { MAX_VEHICLE_YEAR, MIN_VEHICLE_YEAR } from "~/lib/search-filter-bounds";
 import { algoliaHitToSearchVehicle } from "~/lib/search-vehicles";
 
 describe("algolia alert search helpers", () => {
@@ -75,6 +76,18 @@ describe("algolia alert search helpers", () => {
     );
     expect(swappedRange).toContain("year >= 2015");
     expect(swappedRange).toContain("year <= 2020");
+  });
+
+  test("clamps years to sane vehicle bounds", () => {
+    const filters = buildAlertFiltersString(
+      {
+        minYear: MIN_VEHICLE_YEAR - 20,
+        maxYear: MAX_VEHICLE_YEAR + 50,
+      },
+      null,
+    );
+
+    expect(filters).toBeUndefined();
   });
 
   test("maps algolia hits to search vehicle shape", () => {

--- a/src/lib/__tests__/algolia-alert-search.test.ts
+++ b/src/lib/__tests__/algolia-alert-search.test.ts
@@ -5,7 +5,10 @@ import {
   getAlertMatchStats,
 } from "~/lib/algolia-alert-search";
 import { searchClient } from "~/lib/algolia-search";
-import { MAX_VEHICLE_YEAR, MIN_VEHICLE_YEAR } from "~/lib/search-filter-bounds";
+import {
+  getMaxVehicleYear,
+  MIN_VEHICLE_YEAR,
+} from "~/lib/search-filter-bounds";
 import { algoliaHitToSearchVehicle } from "~/lib/search-vehicles";
 
 describe("algolia alert search helpers", () => {
@@ -79,10 +82,11 @@ describe("algolia alert search helpers", () => {
   });
 
   test("clamps years to sane vehicle bounds", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const filters = buildAlertFiltersString(
       {
         minYear: MIN_VEHICLE_YEAR - 20,
-        maxYear: MAX_VEHICLE_YEAR + 50,
+        maxYear: maxVehicleYear + 50,
       },
       null,
     );

--- a/src/lib/__tests__/saved-search-filters.test.ts
+++ b/src/lib/__tests__/saved-search-filters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { filtersSchema } from "~/lib/saved-search-filters";
 import {
-  MAX_VEHICLE_YEAR,
+  getMaxVehicleYear,
   MIN_VEHICLE_YEAR,
 } from "~/lib/search-filter-bounds";
 
@@ -23,17 +23,19 @@ describe("saved search filters schema", () => {
   });
 
   test("rejects years outside supported bounds", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const tooOld = filtersSchema.safeParse({ minYear: MIN_VEHICLE_YEAR - 1 });
-    const tooNew = filtersSchema.safeParse({ maxYear: MAX_VEHICLE_YEAR + 1 });
+    const tooNew = filtersSchema.safeParse({ maxYear: maxVehicleYear + 1 });
 
     expect(tooOld.success).toBe(false);
     expect(tooNew.success).toBe(false);
   });
 
   test("accepts valid integer years and known sources", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const result = filtersSchema.safeParse({
       minYear: 2012,
-      maxYear: MAX_VEHICLE_YEAR,
+      maxYear: maxVehicleYear,
       sources: ["pyp", "row52", "pullapart", "upullitne"],
     });
 
@@ -41,11 +43,16 @@ describe("saved search filters schema", () => {
   });
 
   test("accepts very old but still valid vehicle years", () => {
-    const result = filtersSchema.safeParse({
+    const historicalResult = filtersSchema.safeParse({
       minYear: MIN_VEHICLE_YEAR,
-      maxYear: 1908,
+      maxYear: MIN_VEHICLE_YEAR + 22,
+    });
+    const currentMaxYearResult = filtersSchema.safeParse({
+      minYear: getMaxVehicleYear() - 5,
+      maxYear: getMaxVehicleYear(),
     });
 
-    expect(result.success).toBe(true);
+    expect(historicalResult.success).toBe(true);
+    expect(currentMaxYearResult.success).toBe(true);
   });
 });

--- a/src/lib/__tests__/saved-search-filters.test.ts
+++ b/src/lib/__tests__/saved-search-filters.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { filtersSchema } from "~/lib/saved-search-filters";
+import {
+  MAX_VEHICLE_YEAR,
+  MIN_VEHICLE_YEAR,
+} from "~/lib/search-filter-bounds";
 
 describe("saved search filters schema", () => {
   test("rejects invalid data sources", () => {
@@ -19,21 +23,27 @@ describe("saved search filters schema", () => {
   });
 
   test("rejects years outside supported bounds", () => {
-    const tooOld = filtersSchema.safeParse({ minYear: 1800 });
-    const tooNew = filtersSchema.safeParse({
-      maxYear: new Date().getUTCFullYear() + 2,
-    });
+    const tooOld = filtersSchema.safeParse({ minYear: MIN_VEHICLE_YEAR - 1 });
+    const tooNew = filtersSchema.safeParse({ maxYear: MAX_VEHICLE_YEAR + 1 });
 
     expect(tooOld.success).toBe(false);
     expect(tooNew.success).toBe(false);
   });
 
   test("accepts valid integer years and known sources", () => {
-    const nextYear = new Date().getUTCFullYear() + 1;
     const result = filtersSchema.safeParse({
       minYear: 2012,
-      maxYear: nextYear,
+      maxYear: MAX_VEHICLE_YEAR,
       sources: ["pyp", "row52", "pullapart", "upullitne"],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts very old but still valid vehicle years", () => {
+    const result = filtersSchema.safeParse({
+      minYear: MIN_VEHICLE_YEAR,
+      maxYear: 1908,
     });
 
     expect(result.success).toBe(true);

--- a/src/lib/__tests__/search-filter-bounds.test.ts
+++ b/src/lib/__tests__/search-filter-bounds.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_VEHICLE_YEAR,
+  mergeSelectedFilterOptions,
+  MIN_VEHICLE_YEAR,
+  normalizeVehicleYearFilter,
+} from "~/lib/search-filter-bounds";
+
+describe("search filter bounds", () => {
+  test("normalizes empty year filters to the full supported range", () => {
+    const result = normalizeVehicleYearFilter(undefined, undefined);
+
+    expect(result.range).toEqual([MIN_VEHICLE_YEAR, MAX_VEHICLE_YEAR]);
+    expect(result.minYear).toBeUndefined();
+    expect(result.maxYear).toBeUndefined();
+    expect(result.isFiltered).toBe(false);
+  });
+
+  test("clamps and sorts inverted year filters", () => {
+    const result = normalizeVehicleYearFilter(
+      MAX_VEHICLE_YEAR + 10,
+      MIN_VEHICLE_YEAR - 10,
+    );
+
+    expect(result.range).toEqual([MIN_VEHICLE_YEAR, MAX_VEHICLE_YEAR]);
+    expect(result.minYear).toBeUndefined();
+    expect(result.maxYear).toBeUndefined();
+    expect(result.isFiltered).toBe(false);
+  });
+
+  test("keeps partial year filters when only one side is set", () => {
+    const result = normalizeVehicleYearFilter(2027, undefined);
+
+    expect(result.range).toEqual([2027, MAX_VEHICLE_YEAR]);
+    expect(result.minYear).toBe(2027);
+    expect(result.maxYear).toBeUndefined();
+    expect(result.isFiltered).toBe(true);
+  });
+
+  test("merges selected filter values back into available options", () => {
+    const result = mergeSelectedFilterOptions(
+      ["Acura", "Toyota"],
+      ["Honda", "Toyota"],
+    );
+
+    expect(result).toEqual(["Acura", "Honda", "Toyota"]);
+  });
+});

--- a/src/lib/__tests__/search-filter-bounds.test.ts
+++ b/src/lib/__tests__/search-filter-bounds.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  MAX_VEHICLE_YEAR,
+  getMaxVehicleYear,
   mergeSelectedFilterOptions,
   MIN_VEHICLE_YEAR,
   normalizeVehicleYearFilter,
@@ -8,30 +8,33 @@ import {
 
 describe("search filter bounds", () => {
   test("normalizes empty year filters to the full supported range", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const result = normalizeVehicleYearFilter(undefined, undefined);
 
-    expect(result.range).toEqual([MIN_VEHICLE_YEAR, MAX_VEHICLE_YEAR]);
+    expect(result.range).toEqual([MIN_VEHICLE_YEAR, maxVehicleYear]);
     expect(result.minYear).toBeUndefined();
     expect(result.maxYear).toBeUndefined();
     expect(result.isFiltered).toBe(false);
   });
 
   test("clamps and sorts inverted year filters", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const result = normalizeVehicleYearFilter(
-      MAX_VEHICLE_YEAR + 10,
+      maxVehicleYear + 10,
       MIN_VEHICLE_YEAR - 10,
     );
 
-    expect(result.range).toEqual([MIN_VEHICLE_YEAR, MAX_VEHICLE_YEAR]);
+    expect(result.range).toEqual([MIN_VEHICLE_YEAR, maxVehicleYear]);
     expect(result.minYear).toBeUndefined();
     expect(result.maxYear).toBeUndefined();
     expect(result.isFiltered).toBe(false);
   });
 
   test("keeps partial year filters when only one side is set", () => {
+    const maxVehicleYear = getMaxVehicleYear();
     const result = normalizeVehicleYearFilter(2027, undefined);
 
-    expect(result.range).toEqual([2027, MAX_VEHICLE_YEAR]);
+    expect(result.range).toEqual([2027, maxVehicleYear]);
     expect(result.minYear).toBe(2027);
     expect(result.maxYear).toBeUndefined();
     expect(result.isFiltered).toBe(true);

--- a/src/lib/algolia-alert-search.ts
+++ b/src/lib/algolia-alert-search.ts
@@ -1,4 +1,5 @@
 import { algoliaHitToSearchVehicle } from "~/lib/search-vehicles";
+import { normalizeVehicleYearFilter } from "~/lib/search-filter-bounds";
 import type { SearchVehicle } from "~/lib/types";
 import { ALGOLIA_INDEX_NAME, searchClient } from "~/lib/algolia-search";
 
@@ -76,12 +77,10 @@ export function buildAlertFiltersString(
   );
   if (sourcesClause) clauses.push(sourcesClause);
 
-  let minYear = Number.isFinite(filters.minYear) ? filters.minYear : undefined;
-  let maxYear = Number.isFinite(filters.maxYear) ? filters.maxYear : undefined;
-
-  if (minYear !== undefined && maxYear !== undefined && minYear > maxYear) {
-    [minYear, maxYear] = [maxYear, minYear];
-  }
+  const { minYear, maxYear } = normalizeVehicleYearFilter(
+    filters.minYear,
+    filters.maxYear,
+  );
 
   if (minYear !== undefined) {
     clauses.push(`year >= ${minYear}`);

--- a/src/lib/saved-search-filters.ts
+++ b/src/lib/saved-search-filters.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  MAX_VEHICLE_YEAR,
+  MIN_VEHICLE_YEAR,
+} from "~/lib/search-filter-bounds";
 
 const SOURCE_VALUES = [
   "pyp",
@@ -7,8 +11,6 @@ const SOURCE_VALUES = [
   "pullapart",
   "upullitne",
 ] as const;
-const MIN_VEHICLE_YEAR = 1886;
-const MAX_VEHICLE_YEAR = new Date().getUTCFullYear() + 1;
 
 export const filtersSchema = z.object({
   makes: z.array(z.string()).optional(),

--- a/src/lib/saved-search-filters.ts
+++ b/src/lib/saved-search-filters.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  MAX_VEHICLE_YEAR,
+  getMaxVehicleYear,
   MIN_VEHICLE_YEAR,
 } from "~/lib/search-filter-bounds";
 
@@ -12,24 +12,22 @@ const SOURCE_VALUES = [
   "upullitne",
 ] as const;
 
+const vehicleYearSchema = z
+  .number()
+  .int()
+  .min(MIN_VEHICLE_YEAR)
+  .refine((year) => year <= getMaxVehicleYear(), {
+    message: "Vehicle year must be no later than next model year.",
+  });
+
 export const filtersSchema = z.object({
   makes: z.array(z.string()).optional(),
   colors: z.array(z.string()).optional(),
   states: z.array(z.string()).optional(),
   salvageYards: z.array(z.string()).optional(),
   sources: z.array(z.enum(SOURCE_VALUES)).optional(),
-  minYear: z
-    .number()
-    .int()
-    .min(MIN_VEHICLE_YEAR)
-    .max(MAX_VEHICLE_YEAR)
-    .optional(),
-  maxYear: z
-    .number()
-    .int()
-    .min(MIN_VEHICLE_YEAR)
-    .max(MAX_VEHICLE_YEAR)
-    .optional(),
+  minYear: vehicleYearSchema.optional(),
+  maxYear: vehicleYearSchema.optional(),
   sortBy: z.string().optional(),
 });
 

--- a/src/lib/search-filter-bounds.ts
+++ b/src/lib/search-filter-bounds.ts
@@ -1,0 +1,61 @@
+export const MIN_VEHICLE_YEAR = 1886;
+export const MAX_VEHICLE_YEAR = new Date().getUTCFullYear() + 1;
+
+export function clampVehicleYear(
+  value: number | null | undefined,
+  min = MIN_VEHICLE_YEAR,
+  max = MAX_VEHICLE_YEAR,
+): number | undefined {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+export function normalizeVehicleYearFilter(
+  minYear: number | null | undefined,
+  maxYear: number | null | undefined,
+  min = MIN_VEHICLE_YEAR,
+  max = MAX_VEHICLE_YEAR,
+): {
+  minYear: number | undefined;
+  maxYear: number | undefined;
+  range: [number, number];
+  isFiltered: boolean;
+} {
+  let normalizedMinYear = clampVehicleYear(minYear, min, max);
+  let normalizedMaxYear = clampVehicleYear(maxYear, min, max);
+
+  if (
+    normalizedMinYear !== undefined &&
+    normalizedMaxYear !== undefined &&
+    normalizedMinYear > normalizedMaxYear
+  ) {
+    [normalizedMinYear, normalizedMaxYear] = [
+      normalizedMaxYear,
+      normalizedMinYear,
+    ];
+  }
+
+  const range: [number, number] = [
+    normalizedMinYear ?? min,
+    normalizedMaxYear ?? max,
+  ];
+
+  return {
+    minYear: range[0] === min ? undefined : range[0],
+    maxYear: range[1] === max ? undefined : range[1],
+    range,
+    isFiltered: range[0] !== min || range[1] !== max,
+  };
+}
+
+export function mergeSelectedFilterOptions(
+  availableOptions: string[],
+  selectedOptions: string[],
+): string[] {
+  return [...new Set([...selectedOptions, ...availableOptions])]
+    .filter((option) => option.trim().length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}

--- a/src/lib/search-filter-bounds.ts
+++ b/src/lib/search-filter-bounds.ts
@@ -1,10 +1,13 @@
 export const MIN_VEHICLE_YEAR = 1886;
-export const MAX_VEHICLE_YEAR = new Date().getUTCFullYear() + 1;
+
+export function getMaxVehicleYear(): number {
+  return new Date().getUTCFullYear() + 1;
+}
 
 export function clampVehicleYear(
   value: number | null | undefined,
   min = MIN_VEHICLE_YEAR,
-  max = MAX_VEHICLE_YEAR,
+  max = getMaxVehicleYear(),
 ): number | undefined {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return undefined;
@@ -17,7 +20,7 @@ export function normalizeVehicleYearFilter(
   minYear: number | null | undefined,
   maxYear: number | null | undefined,
   min = MIN_VEHICLE_YEAR,
-  max = MAX_VEHICLE_YEAR,
+  max = getMaxVehicleYear(),
 ): {
   minYear: number | undefined;
   maxYear: number | undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow year filters and saved searches to use sane global vehicle bounds instead of the current indexed inventory bounds
- preserve selected facet values in the filters UI even when the current result set no longer exposes those options
- centralize year-bound normalization so saved-search validation, URL state, and alert filter generation stay consistent
- fix the year slider so dragging updates the live InstantSearch UI state and keeps the URL in sync
- memoize route-year normalization and compute max vehicle year dynamically at parse time so long-running processes do not drift stale

## Testing
- `bun test src/lib/__tests__/search-filter-bounds.test.ts src/lib/__tests__/saved-search-filters.test.ts src/lib/__tests__/algolia-alert-search.test.ts`
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- Playwright-driven browser verification that dragging the year slider updates both the visible range and the `minYear` URL param
- manual browser verification of preserved future-year filters and empty-results state

## Walkthrough
[year_slider_drag_fix_demo.mp4](https://cursor.com/agents/bc-b0a0f303-bb46-4143-a979-6c5dee40b30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyear_slider_drag_fix_demo.mp4)

[Year slider drag after fix](https://cursor.com/agents/bc-b0a0f303-bb46-4143-a979-6c5dee40b30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyear_slider_drag_after_fix.png)

[global_filter_bounds_demo.mp4](https://cursor.com/agents/bc-b0a0f303-bb46-4143-a979-6c5dee40b30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fglobal_filter_bounds_demo.mp4)

[Filter bounds empty state](https://cursor.com/agents/bc-b0a0f303-bb46-4143-a979-6c5dee40b30e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilter_bounds_empty_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0a0f303-bb46-4143-a979-6c5dee40b30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a0f303-bb46-4143-a979-6c5dee40b30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Year filter bounds are now optional, allowing searches without explicit min/max year
  * Make filter section now appears when any makes exist
  * Vehicle year validation and clamping are consistent across search, saved filters, and alerts
  * Filter option lists reliably include currently selected values without duplicates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->