### PR TITLE
feat: searchable, height-capped filter lists for better mobile UX

### DIFF
--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -1397,23 +1397,30 @@ function AlgoliaSearchInner({
             !isSearching &&
             !error && (
               <div className="py-12 text-center">
-                <div className="bg-muted mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full">
-                  <AlertCircle className="text-muted-foreground h-12 w-12" />
+                <div className="bg-muted mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                  <AlertCircle className="text-muted-foreground h-8 w-8" />
                 </div>
                 <h2 className="text-foreground mb-2 text-lg font-medium">
                   No vehicles found
                 </h2>
-                <p className="text-muted-foreground mx-auto mb-6 max-w-md">
+                <p className="text-muted-foreground mx-auto max-w-sm text-sm">
                   {activeFilterCount > 0
-                    ? "No vehicles match your current filters. Try adjusting your filters."
-                    : "No vehicles match your search. Try different search terms."}
+                    ? "No vehicles match your current filters. Try broadening your search."
+                    : "No vehicles match your search. Try different terms."}
                 </p>
-                <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-                  {activeFilterCount > 0 && (
-                    <Button onClick={clearAllFilters} variant="outline">
-                      Clear All Filters
-                    </Button>
-                  )}
+
+                {activeFilterCount > 0 && (
+                  <Button
+                    onClick={clearAllFilters}
+                    variant="outline"
+                    size="sm"
+                    className="mt-5"
+                  >
+                    Clear Filters
+                  </Button>
+                )}
+
+                <p className="text-muted-foreground mt-6 text-xs">
                   {isLoggedIn ? (
                     <SaveSearchDialog
                       query={query}
@@ -1422,46 +1429,44 @@ function AlgoliaSearchInner({
                       isLoggedIn={isLoggedIn}
                     />
                   ) : (
-                    <Button asChild>
-                      <Link
-                        href={saveSearchSignUpHref}
-                        onClick={() => {
-                          storePendingSaveSearch(query, currentSaveSearchFilters);
-                          posthog.capture(
-                            AnalyticsEvents.RESULT_CAP_SIGNUP_CLICKED,
-                            {
-                              source_page: "search",
-                              cta_location: "no_results",
-                              query,
-                              result_count: 0,
-                              visible_result_count: 0,
-                            },
-                          );
-                        }}
-                      >
-                        Create free account to save this search
-                      </Link>
-                    </Button>
-                  )}
-                  <Button asChild variant="outline">
                     <Link
-                      href="/pricing"
-                      onClick={() =>
-                        posthog.capture(AnalyticsEvents.PRICING_CTA_CLICKED, {
-                          source_page: "search",
-                          cta_location: "no_results",
-                          query,
-                          result_count: 0,
-                          visible_result_count: 0,
-                          is_logged_in: isLoggedIn,
-                        })
-                      }
+                      href={saveSearchSignUpHref}
+                      className="hover:text-foreground underline underline-offset-2"
+                      onClick={() => {
+                        storePendingSaveSearch(query, currentSaveSearchFilters);
+                        posthog.capture(
+                          AnalyticsEvents.RESULT_CAP_SIGNUP_CLICKED,
+                          {
+                            source_page: "search",
+                            cta_location: "no_results",
+                            query,
+                            result_count: 0,
+                            visible_result_count: 0,
+                          },
+                        );
+                      }}
                     >
-                      Get alerts for $
-                      {MONETIZATION_CONFIG.ALERTS_PLAN_PRICE_MONTHLY}/mo
+                      Save this search
                     </Link>
-                  </Button>
-                </div>
+                  )}{" "}
+                  ·{" "}
+                  <Link
+                    href="/pricing"
+                    className="hover:text-foreground underline underline-offset-2"
+                    onClick={() =>
+                      posthog.capture(AnalyticsEvents.PRICING_CTA_CLICKED, {
+                        source_page: "search",
+                        cta_location: "no_results",
+                        query,
+                        result_count: 0,
+                        visible_result_count: 0,
+                        is_logged_in: isLoggedIn,
+                      })
+                    }
+                  >
+                    Get alerts
+                  </Link>
+                </p>
               </div>
             )}
         </div>

--- a/src/components/search/SearchableCheckboxList.tsx
+++ b/src/components/search/SearchableCheckboxList.tsx
@@ -91,12 +91,8 @@ export function SearchableCheckboxList({
       )}
 
       <div
-        className="overflow-y-auto overscroll-contain"
-        style={{
-          maxHeight,
-          scrollbarWidth: "thin",
-          scrollbarColor: "var(--color-muted-foreground) transparent",
-        }}
+        className="scrollbar-thin-themed overflow-y-auto overscroll-contain"
+        style={{ maxHeight }}
       >
         {sorted.length === 0 ? (
           <p className="text-muted-foreground px-3 py-2 text-sm">

--- a/src/components/search/SearchableCheckboxList.tsx
+++ b/src/components/search/SearchableCheckboxList.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Label } from "~/components/ui/label";
+
+interface SearchableCheckboxListProps {
+  /** Unique name used to namespace checkbox ids and avoid DOM collisions. */
+  name: string;
+  options: string[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  searchPlaceholder?: string;
+  /** Show the search input when the number of options exceeds this threshold. */
+  searchThreshold?: number;
+  /** Max visible height (px) before the list scrolls internally. */
+  maxHeight?: number;
+}
+
+export function SearchableCheckboxList({
+  name,
+  options,
+  selected,
+  onChange,
+  searchPlaceholder = "Search…",
+  searchThreshold = 8,
+  maxHeight = 200,
+}: SearchableCheckboxListProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const showSearch = options.length > searchThreshold;
+
+  const filtered = useMemo(() => {
+    if (!query) return options;
+    const lower = query.toLowerCase();
+    return options.filter((o) => o.toLowerCase().includes(lower));
+  }, [options, query]);
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  // Pin selected items to top only when not actively searching
+  const sorted = useMemo(() => {
+    if (query) return filtered;
+    return [...filtered].sort((a, b) => {
+      const aSelected = selectedSet.has(a);
+      const bSelected = selectedSet.has(b);
+      if (aSelected && !bSelected) return -1;
+      if (!aSelected && bSelected) return 1;
+      return 0;
+    });
+  }, [filtered, selectedSet, query]);
+
+  const toggle = (value: string) => {
+    if (selectedSet.has(value)) {
+      onChange(selected.filter((s) => s !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {showSearch && (
+        <div className="relative px-1">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="border-input placeholder:text-muted-foreground focus-visible:ring-ring/50 focus-visible:border-ring h-8 w-full rounded-md border bg-transparent pr-7 pl-8 text-sm outline-none focus-visible:ring-[3px]"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery("");
+                inputRef.current?.focus();
+              }}
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      <div
+        className="overflow-y-auto overscroll-contain"
+        style={{
+          maxHeight,
+          scrollbarWidth: "thin",
+          scrollbarColor: "rgb(203 213 225) transparent",
+        }}
+      >
+        {sorted.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-2 text-sm">
+            No matches
+          </p>
+        ) : (
+          sorted.map((option) => (
+            <div
+              key={option}
+              className="flex items-center space-x-2 rounded px-3 py-1"
+            >
+              <Checkbox
+                id={`${name}-${option}`}
+                checked={selectedSet.has(option)}
+                onCheckedChange={() => toggle(option)}
+              />
+              <Label
+                htmlFor={`${name}-${option}`}
+                className="cursor-pointer text-sm leading-none"
+              >
+                {option}
+              </Label>
+            </div>
+          ))
+        )}
+      </div>
+
+      {selected.length > 0 && (
+        <button
+          type="button"
+          onClick={() => onChange([])}
+          className="text-muted-foreground hover:text-foreground px-3 text-xs underline-offset-2 hover:underline"
+        >
+          Clear selection
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/search/SearchableCheckboxList.tsx
+++ b/src/components/search/SearchableCheckboxList.tsx
@@ -71,11 +71,13 @@ export function SearchableCheckboxList({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={searchPlaceholder}
+            aria-label={searchPlaceholder}
             className="border-input placeholder:text-muted-foreground focus-visible:ring-ring/50 focus-visible:border-ring h-8 w-full rounded-md border bg-transparent pr-7 pl-8 text-sm outline-none focus-visible:ring-[3px]"
           />
           {query && (
             <button
               type="button"
+              aria-label="Clear search"
               onClick={() => {
                 setQuery("");
                 inputRef.current?.focus();
@@ -93,7 +95,7 @@ export function SearchableCheckboxList({
         style={{
           maxHeight,
           scrollbarWidth: "thin",
-          scrollbarColor: "rgb(203 213 225) transparent",
+          scrollbarColor: "var(--color-muted-foreground) transparent",
         }}
       >
         {sorted.length === 0 ? (

--- a/src/components/search/SearchableCheckboxList.tsx
+++ b/src/components/search/SearchableCheckboxList.tsx
@@ -95,9 +95,11 @@ export function SearchableCheckboxList({
         style={{ maxHeight }}
       >
         {sorted.length === 0 ? (
-          <p className="text-muted-foreground px-3 py-2 text-sm">
-            No matches
-          </p>
+          query ? (
+            <p className="text-muted-foreground px-3 py-2 text-sm" role="status" aria-live="polite">
+              No matches
+            </p>
+          ) : null
         ) : (
           sorted.map((option) => (
             <div

--- a/src/components/search/Sidebar.tsx
+++ b/src/components/search/Sidebar.tsx
@@ -98,7 +98,7 @@ export function Sidebar({
                 overflowY: "auto",
                 scrollbarGutter: "stable",
                 scrollbarWidth: "thin",
-                scrollbarColor: "rgb(203 213 225) transparent",
+                scrollbarColor: "var(--color-muted-foreground) transparent",
               }}
             >
               <SidebarContent

--- a/src/components/search/Sidebar.tsx
+++ b/src/components/search/Sidebar.tsx
@@ -92,15 +92,8 @@ export function Sidebar({
               )}
             </CardHeader>
 
-            <CardContent
-              className="ml-2 max-h-[calc(100vh-200px)]"
-              style={{
-                overflowY: "auto",
-                scrollbarGutter: "stable",
-                scrollbarWidth: "thin",
-                scrollbarColor: "var(--color-muted-foreground) transparent",
-              }}
-            >
+            <CardContent className="scrollbar-thin-themed ml-2 max-h-[calc(100vh-200px)] overflow-y-auto [scrollbar-gutter:stable]">
+
               <SidebarContent
                 makes={makes}
                 colors={colors}

--- a/src/components/search/SidebarContent.tsx
+++ b/src/components/search/SidebarContent.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
   Collapsible,
@@ -8,6 +9,7 @@ import {
 import { Label } from "~/components/ui/label";
 import { Slider } from "~/components/ui/slider";
 import type { DataSource } from "~/lib/types";
+import { SearchableCheckboxList } from "./SearchableCheckboxList";
 
 interface FilterOptions {
   makes: string[];
@@ -121,28 +123,26 @@ export function SidebarContent({
       {filterOptions.makes.length > 1 && (
         <Collapsible defaultOpen>
           <CollapsibleTrigger className="hover:bg-accent flex w-full items-center justify-between rounded p-2">
-            <span className="font-medium">Make</span>
+            <div className="flex items-center gap-2">
+              <span className="font-medium">Make</span>
+              {makes.length > 0 && (
+                <Badge variant="secondary" className="text-[10px] tabular-nums">
+                  {makes.length}
+                </Badge>
+              )}
+            </div>
             <ChevronDown className="h-4 w-4" />
           </CollapsibleTrigger>
-          <CollapsibleContent className="mt-2 space-y-2">
-            {filterOptions.makes.map((make) => (
-              <div key={make} className="flex items-center space-x-2 pr-3 pl-3">
-                <Checkbox
-                  id={`make-${make}`}
-                  checked={makes.includes(make)}
-                  onCheckedChange={() => {
-                    if (makes.includes(make)) {
-                      onMakesChange(makes.filter((m) => m !== make));
-                    } else {
-                      onMakesChange([...makes, make]);
-                    }
-                  }}
-                />
-                <Label htmlFor={`make-${make}`} className="text-sm">
-                  {make}
-                </Label>
-              </div>
-            ))}
+          <CollapsibleContent className="mt-2">
+            <SearchableCheckboxList
+              name="make"
+              options={filterOptions.makes}
+              selected={makes}
+              onChange={onMakesChange}
+              searchPlaceholder="Search makes…"
+              searchThreshold={10}
+              maxHeight={220}
+            />
           </CollapsibleContent>
         </Collapsible>
       )}
@@ -177,84 +177,76 @@ export function SidebarContent({
 
       <Collapsible>
         <CollapsibleTrigger className="hover:bg-accent flex w-full items-center justify-between rounded p-2">
-          <span className="font-medium">Color</span>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Color</span>
+            {colors.length > 0 && (
+              <Badge variant="secondary" className="text-[10px] tabular-nums">
+                {colors.length}
+              </Badge>
+            )}
+          </div>
           <ChevronDown className="h-4 w-4" />
         </CollapsibleTrigger>
-        <CollapsibleContent className="mt-2 space-y-2">
-          {filterOptions.colors.map((color) => (
-            <div key={color} className="flex items-center space-x-2 pr-3 pl-3">
-              <Checkbox
-                id={`color-${color}`}
-                checked={colors.includes(color)}
-                onCheckedChange={() => {
-                  if (colors.includes(color)) {
-                    onColorsChange(colors.filter((c) => c !== color));
-                  } else {
-                    onColorsChange([...colors, color]);
-                  }
-                }}
-              />
-              <Label htmlFor={`color-${color}`} className="text-sm">
-                {color}
-              </Label>
-            </div>
-          ))}
+        <CollapsibleContent className="mt-2">
+            <SearchableCheckboxList
+              name="color"
+              options={filterOptions.colors}
+              selected={colors}
+              onChange={onColorsChange}
+              searchPlaceholder="Search colors…"
+              searchThreshold={12}
+              maxHeight={200}
+            />
         </CollapsibleContent>
       </Collapsible>
 
       <Collapsible>
         <CollapsibleTrigger className="hover:bg-accent flex w-full items-center justify-between rounded p-2">
-          <span className="font-medium">State</span>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">State</span>
+            {states.length > 0 && (
+              <Badge variant="secondary" className="text-[10px] tabular-nums">
+                {states.length}
+              </Badge>
+            )}
+          </div>
           <ChevronDown className="h-4 w-4" />
         </CollapsibleTrigger>
-        <CollapsibleContent className="mt-2 space-y-2">
-          {filterOptions.states.map((state) => (
-            <div key={state} className="flex items-center space-x-2 pr-3 pl-3">
-              <Checkbox
-                id={`state-${state}`}
-                checked={states.includes(state)}
-                onCheckedChange={() => {
-                  if (states.includes(state)) {
-                    onStatesChange(states.filter((s) => s !== state));
-                  } else {
-                    onStatesChange([...states, state]);
-                  }
-                }}
-              />
-              <Label htmlFor={`state-${state}`} className="text-sm">
-                {state}
-              </Label>
-            </div>
-          ))}
+        <CollapsibleContent className="mt-2">
+            <SearchableCheckboxList
+              name="state"
+              options={filterOptions.states}
+              selected={states}
+              onChange={onStatesChange}
+              searchPlaceholder="Search states…"
+              searchThreshold={6}
+              maxHeight={240}
+            />
         </CollapsibleContent>
       </Collapsible>
 
       <Collapsible>
         <CollapsibleTrigger className="hover:bg-accent flex w-full items-center justify-between rounded p-2">
-          <span className="font-medium">Lot</span>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Lot</span>
+            {salvageYards.length > 0 && (
+              <Badge variant="secondary" className="text-[10px] tabular-nums">
+                {salvageYards.length}
+              </Badge>
+            )}
+          </div>
           <ChevronDown className="h-4 w-4" />
         </CollapsibleTrigger>
-        <CollapsibleContent className="mt-2 space-y-2">
-          {filterOptions.salvageYards.map((yard) => (
-            <div key={yard} className="flex items-center space-x-2 pr-3 pl-3">
-              <Checkbox
-                id={`yard-${yard}`}
-                checked={salvageYards.includes(yard)}
-                onCheckedChange={() => {
-                  if (salvageYards.includes(yard)) {
-                    onSalvageYardsChange(
-                      salvageYards.filter((y) => y !== yard),
-                    );
-                  } else {
-                    onSalvageYardsChange([...salvageYards, yard]);
-                  }
-                }}
-              />
-              <Label htmlFor={`yard-${yard}`} className="text-sm">
-                {yard}
-              </Label>
-            </div>
-          ))}
+        <CollapsibleContent className="mt-2">
+            <SearchableCheckboxList
+              name="yard"
+              options={filterOptions.salvageYards}
+              selected={salvageYards}
+              onChange={onSalvageYardsChange}
+              searchPlaceholder="Search lots…"
+              searchThreshold={6}
+              maxHeight={240}
+            />
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -124,3 +124,8 @@
     @apply bg-background text-foreground;
   }
 }
+
+@utility scrollbar-thin-themed {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-muted-foreground) transparent;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Selecting a state on mobile is painful — the filter drawer renders all ~50 states as an unbounded checkbox list that inflates the entire drawer, forcing users to scroll through everything with no way to search. The same issue affects Lot (potentially hundreds of locations) and Make (dozens of car brands).

The no-results empty state also had three big competing buttons awkwardly placed with text that wraps badly on mobile.

## Solution

### Searchable filter lists

Created a reusable `SearchableCheckboxList` component and applied it to **Make**, **Color**, **State**, and **Lot** filters.

| Feature | Details |
|---------|---------|
| **Type-ahead search** | Filter input auto-appears when a section has many options (configurable threshold). Substring match, case-insensitive. |
| **Capped scroll height** | Each filter section scrolls independently within a fixed `maxHeight` container with `overscroll-contain`, preventing the entire sidebar/drawer from becoming enormous. |
| **Selected pinned to top** | When no search query is active, selected items float to the top of the list so you can see your selections at a glance. |
| **Count badges** | Section headers now show a small badge with the number of active selections. |
| **Clear selection** | One-tap "Clear selection" link below the list to deselect all within that section. |
| **Accessible** | Search input and clear button have proper `aria-label` attributes. |
| **Theme-aware scrollbars** | `scrollbar-thin-themed` CSS utility uses `var(--color-muted-foreground)` instead of hardcoded colors. |

### No-results empty state cleanup

- Shrunk the oversized icon
- Tightened copy and constrained width
- Replaced three competing buttons with a single "Clear Filters" button (only when filters are active) and understated text links for save-search and pricing

### What's unchanged

- **Salvage Yards** (sources) still uses the original checkbox pattern — only 5 fixed options, no search needed.
- **Year Range** slider is unchanged.
- All filter logic, URL routing, and Algolia integration are untouched.

## Before / After — No results

**Before:** Three big buttons competing for attention, awkward text wrapping

**After:**
[No results with filters — clean single CTA](https://cursor.com/agents/bc-10ed1667-11f9-4825-b2d9-f6bf1971f3d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fno_results_with_filters_review.png)
[No results without filters — minimal](https://cursor.com/agents/bc-10ed1667-11f9-4825-b2d9-f6bf1971f3d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fno_results_no_filters_review.png)

## Filter UX Demo

[demo_searchable_filters_ux.mp4](https://cursor.com/agents/bc-10ed1667-11f9-4825-b2d9-f6bf1971f3d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_searchable_filters_ux.mp4)

## Testing

- `tsc --noEmit` — passes
- `oxlint .` — 0 warnings, 0 errors
- `bun test src` — 80/80 tests pass
- Manual testing in browser confirms all filter interactions and empty states work correctly

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10ed1667-11f9-4825-b2d9-f6bf1971f3d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10ed1667-11f9-4825-b2d9-f6bf1971f3d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable checkbox lists added to sidebar filters (Make, Color, State, Lot) with incremental search, clear-selection control, “No matches” feedback, selected items pinned to top when not searching, and internal scrolling.
  * Badge counts display number of selected filters.
  * Updated empty-state: tightened layout, revised copy encouraging broader searches, small “Clear Filters” button, conditional “Save this search” (or save dialog) link, and an underlined “Get alerts” link.
* **Style**
  * Sidebar scrollbar styling updated to use a theme-aware thin scrollbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->