### PR TITLE
Fix auth proxy for preview deployments

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -31,6 +31,7 @@ export const env = createEnv({
     BETTERSTACK_HEARTBEAT_URL: z.string().url().optional(),
     // Hyperbrowser (remote browser for PYP scraping, only needed in Trigger.dev worker)
     HYPERBROWSER_API_KEY: z.string().optional(),
+    VERCEL_PROJECT_PRODUCTION_URL: z.string().optional(),
   },
 
   /**
@@ -77,6 +78,7 @@ export const env = createEnv({
     ALGOLIA_WRITE_API_KEY: process.env.ALGOLIA_WRITE_API_KEY,
     BETTERSTACK_HEARTBEAT_URL: process.env.BETTERSTACK_HEARTBEAT_URL,
     HYPERBROWSER_API_KEY: process.env.HYPERBROWSER_API_KEY,
+    VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
     NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
     NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY:
       process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,13 +25,21 @@ export const polarClient = new Polar({
   accessToken: env.POLAR_ACCESS_TOKEN,
 });
 
+const productionURL = env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${env.VERCEL_PROJECT_PRODUCTION_URL}`
+  : env.NEXT_PUBLIC_APP_URL;
+
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "sqlite",
     schema,
   }),
   baseURL: env.NEXT_PUBLIC_APP_URL,
-  trustedOrigins: [env.NEXT_PUBLIC_APP_URL],
+  trustedOrigins: [
+    env.NEXT_PUBLIC_APP_URL,
+    productionURL,
+    "https://*.vercel.app",
+  ],
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }) => {
@@ -53,7 +61,7 @@ export const auth = betterAuth({
     discord: {
       clientId: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
-      redirectURI: `${env.NEXT_PUBLIC_APP_URL}/api/auth/callback/discord`,
+      redirectURI: `${productionURL}/api/auth/callback/discord`,
     },
   },
   databaseHooks: {
@@ -74,7 +82,7 @@ export const auth = betterAuth({
   },
   secret: env.BETTER_AUTH_SECRET,
   plugins: [
-    oAuthProxy(),
+    oAuthProxy({ productionURL }),
     polar({
       client: polarClient,
       createCustomerOnSignUp: true,


### PR DESCRIPTION
## Summary
- Configure Better Auth's OAuth proxy with the production Vercel URL.
- Use the production Discord callback URL while allowing Vercel preview origins.
- Add `VERCEL_PROJECT_PRODUCTION_URL` to env validation/runtime mapping.

## Test plan
- `SKIP_ENV_VALIDATION=1 bun run check`


Made with [Cursor](https://cursor.com)