### PR TITLE
Make homepage search navigation instant

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import("next").NextConfig} */
 const config = {
+  cacheComponents: true,
   images: {
     loader: "custom",
     loaderFile: "./src/lib/wsrvLoader.ts",

--- a/src/app/auth/[...pathname]/page.tsx
+++ b/src/app/auth/[...pathname]/page.tsx
@@ -2,7 +2,7 @@
 
 import posthog from "posthog-js";
 import { useParams } from "next/navigation";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { AuthCard } from "~/components/auth/AuthCard";
 import { ForgotPasswordForm } from "~/components/auth/ForgotPasswordForm";
 import { ResetPasswordForm } from "~/components/auth/ResetPasswordForm";
@@ -40,6 +40,14 @@ const routeConfig: Record<
 };
 
 export default function AuthPage() {
+  return (
+    <Suspense fallback={<AuthPageFallback />}>
+      <AuthPageContent />
+    </Suspense>
+  );
+}
+
+function AuthPageContent() {
   const params = useParams<{ pathname: string[] }>();
   const pathname = (params.pathname?.join("/") || "sign-in") as AuthRoute;
 
@@ -78,6 +86,21 @@ export default function AuthPage() {
         <AuthCard title={title} description={description}>
           <Form />
         </AuthCard>
+      </div>
+    </div>
+  );
+}
+
+function AuthPageFallback() {
+  return (
+    <div className="flex min-h-svh flex-col sm:items-center sm:justify-center sm:p-4">
+      <div className="flex flex-1 flex-col px-6 pt-16 pb-8 sm:hidden">
+        <div className="bg-muted mb-4 h-9 w-48 rounded" />
+        <div className="bg-muted h-5 w-64 rounded" />
+      </div>
+      <div className="bg-card hidden w-full max-w-md rounded-lg border p-8 sm:block">
+        <div className="bg-muted mx-auto mb-3 h-8 w-40 rounded" />
+        <div className="bg-muted mx-auto h-4 w-56 rounded" />
       </div>
     </div>
   );

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,21 +1,28 @@
+import { Suspense } from "react";
 import { headers } from "next/headers";
 import { ContactForm } from "~/components/contact/ContactForm";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
+import { StaticHeader } from "~/components/StaticHeader";
 import { auth } from "~/lib/auth";
 
 export default async function ContactPage() {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
   return (
     <div className="bg-background min-h-screen">
-      <Header />
+      <StaticHeader />
       <main className="mx-auto max-w-xl px-4 py-12 sm:px-6 lg:px-8">
-        <ContactForm initialEmail={session?.user?.email} />
+        <Suspense fallback={<ContactForm />}>
+          <PersonalizedContactForm />
+        </Suspense>
       </main>
       <Footer />
     </div>
   );
+}
+
+async function PersonalizedContactForm() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  return <ContactForm initialEmail={session?.user?.email} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,12 +3,9 @@ import "~/styles/globals.css";
 import { Analytics } from "@vercel/analytics/next";
 import { type Metadata } from "next";
 import { Geist } from "next/font/google";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Toaster } from "~/components/ui/sonner";
 
 import { TailwindIndicator } from "~/components/tailwind-indicator";
-import { ThemeProvider } from "~/components/theme/theme-provider";
-import { TRPCReactProvider } from "~/trpc/react";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://junkyardindex.com";
 
@@ -74,20 +71,9 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geist.variable}`} suppressHydrationWarning>
       <body>
-        <NuqsAdapter>
-          <TRPCReactProvider>
-            <ThemeProvider
-              attribute="class"
-              defaultTheme="system"
-              enableSystem
-              disableTransitionOnChange
-            >
-              {children}
-              <Analytics />
-              <TailwindIndicator />
-            </ThemeProvider>
-          </TRPCReactProvider>
-        </NuqsAdapter>
+        {children}
+        <Analytics />
+        <TailwindIndicator />
         <Toaster />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 import { ArrowRight, Bell, Car, Search } from "lucide-react";
 import { type Metadata } from "next";
 import Link from "next/link";
+import { Suspense } from "react";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
+import { StaticHeader } from "~/components/StaticHeader";
 import { HomeSearchHero } from "~/components/home/HomeSearchHero";
 import { TrackedPricingButton } from "~/components/marketing/TrackedPricingButton";
 import { Badge } from "~/components/ui/badge";
@@ -30,13 +31,35 @@ function formatYardCount(count: number): string {
 }
 
 export default async function Home() {
-  const liveStats = await api.stats.live();
-
   return (
     <div className="bg-background flex min-h-dvh flex-col">
-      <Header />
+      <StaticHeader />
 
       <main className="flex-1">
+        <Suspense fallback={<HomeContent />}>
+          <HomeContentWithLiveStats />
+        </Suspense>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+async function HomeContentWithLiveStats() {
+  const liveStats = await api.stats.live();
+
+  return <HomeContent liveStats={liveStats} />;
+}
+
+function HomeContent({
+  liveStats = { vehicleCount: 0, yardCount: 0 },
+}: {
+  liveStats?: { vehicleCount: number; yardCount: number };
+}) {
+
+  return (
+    <>
         {/* Hero */}
         <section className="px-4 py-10 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
           <div className="mx-auto grid max-w-6xl gap-8 sm:gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
@@ -201,10 +224,7 @@ export default async function Home() {
             </div>
           </div>
         </section>
-      </main>
-
-      <Footer />
-    </div>
+    </>
   );
 }
 

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,7 +1,7 @@
 import { type Metadata } from "next";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
 import { TrackedPricingButton } from "~/components/marketing/TrackedPricingButton";
+import { StaticHeader } from "~/components/StaticHeader";
 import { MONETIZATION_CONFIG } from "~/lib/constants";
 
 export const metadata: Metadata = {
@@ -16,9 +16,9 @@ export const metadata: Metadata = {
 export default function PricingPage() {
   return (
     <div className="bg-background flex min-h-dvh flex-col">
-      <Header />
+      <StaticHeader />
 
-      <main className="flex-1 px-4 py-16 sm:px-6 lg:px-8">
+        <main className="flex-1 px-4 py-16 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-5xl">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-muted-foreground text-sm font-medium">
@@ -94,7 +94,7 @@ export default function PricingPage() {
             </div>
           </div>
         </div>
-      </main>
+        </main>
 
       <Footer />
     </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 import { type Metadata } from "next";
 import Link from "next/link";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
+import { StaticHeader } from "~/components/StaticHeader";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function PrivacyPage() {
   return (
     <div className="bg-background min-h-screen">
-      <Header />
+      <StaticHeader />
 
       {/* Content */}
       <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,9 +2,9 @@ import { type Metadata } from "next";
 import { Suspense } from "react";
 import { ErrorBoundary } from "~/components/ErrorBoundary";
 import { Footer } from "~/components/Footer";
-import { HeaderContent } from "~/components/HeaderContent";
 import { ScrollToTop } from "~/components/ScrollToTop";
-import { SearchPageContent } from "~/components/search/SearchPageContent";
+import { SearchPageWithProviders } from "~/components/search/SearchPageWithProviders";
+import { StaticHeader } from "~/components/StaticHeader";
 import { SearchVisibilityProvider } from "~/context/SearchVisibilityContext";
 
 export const metadata: Metadata = {
@@ -20,11 +20,11 @@ export default async function SearchPage() {
   return (
     <SearchVisibilityProvider>
       <div className="bg-background flex min-h-svh flex-col">
-        <HeaderContent user={null} statusData={null} />
+        <StaticHeader />
         <div className="flex-1">
           <ErrorBoundary>
             <Suspense>
-              <SearchPageContent />
+              <SearchPageWithProviders />
             </Suspense>
           </ErrorBoundary>
         </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,14 +1,11 @@
-import { geolocation } from "@vercel/functions";
 import { type Metadata } from "next";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import { ErrorBoundary } from "~/components/ErrorBoundary";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
+import { HeaderContent } from "~/components/HeaderContent";
 import { ScrollToTop } from "~/components/ScrollToTop";
 import { SearchPageContent } from "~/components/search/SearchPageContent";
 import { SearchVisibilityProvider } from "~/context/SearchVisibilityContext";
-import { auth } from "~/lib/auth";
 
 export const metadata: Metadata = {
   title: "Search Salvage Yard Inventory",
@@ -20,38 +17,14 @@ export const metadata: Metadata = {
 };
 
 export default async function SearchPage() {
-  const reqHeaders = await headers();
-
-  const [session, geo] = await Promise.all([
-    auth.api.getSession({ headers: reqHeaders }),
-    Promise.resolve().then(() => {
-      try {
-        // Vercel edge geolocation — available on Vercel deployments
-        const g = geolocation({ headers: reqHeaders });
-        if (g?.latitude && g?.longitude) {
-          return {
-            lat: parseFloat(g.latitude),
-            lng: parseFloat(g.longitude),
-          };
-        }
-      } catch {
-        // Not on Vercel or geolocation unavailable
-      }
-      return undefined;
-    }),
-  ]);
-
   return (
     <SearchVisibilityProvider>
       <div className="bg-background flex min-h-svh flex-col">
-        <Header />
+        <HeaderContent user={null} statusData={null} />
         <div className="flex-1">
           <ErrorBoundary>
             <Suspense>
-              <SearchPageContent
-                isLoggedIn={!!session?.user}
-                userLocation={geo}
-              />
+              <SearchPageContent />
             </Suspense>
           </ErrorBoundary>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,13 +1,13 @@
 import { Suspense } from "react";
 import { Footer } from "~/components/Footer";
-import { Header } from "~/components/Header";
-import { SettingsDashboard } from "~/components/settings/SettingsDashboard";
+import { StaticHeader } from "~/components/StaticHeader";
+import { SettingsDashboardWithProviders } from "~/components/settings/SettingsDashboardWithProviders";
 import { Skeleton } from "~/components/ui/skeleton";
 
 export default function SettingsPage() {
   return (
     <div className="bg-background min-h-screen">
-      <Header />
+      <StaticHeader />
 
       <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         <div className="mb-8">
@@ -26,7 +26,7 @@ export default function SettingsPage() {
             </div>
           }
         >
-          <SettingsDashboard />
+          <SettingsDashboardWithProviders />
         </Suspense>
       </main>
 

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { db } from "~/lib/db";
 import { verifyUnsubscribeToken } from "~/lib/email";
 import { savedSearch } from "~/schema";
@@ -12,6 +13,14 @@ interface UnsubscribePageProps {
 export default async function UnsubscribePage({
   searchParams,
 }: UnsubscribePageProps) {
+  return (
+    <Suspense fallback={<UnsubscribeLoading />}>
+      <UnsubscribeContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function UnsubscribeContent({ searchParams }: UnsubscribePageProps) {
   const { id: searchId, token, done } = await searchParams;
 
   // Validate token using HMAC verification
@@ -137,6 +146,17 @@ export default async function UnsubscribePage({
       >
         Cancel
       </Link>
+    </div>
+  );
+}
+
+function UnsubscribeLoading() {
+  return (
+    <div className="mx-auto max-w-md px-4 py-24 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">Loading unsubscribe link...</h1>
+      <p className="text-muted-foreground mb-8">
+        Checking your alert preferences.
+      </p>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
+import { cacheLife } from "next/cache";
 import { env } from "~/env";
 
-export function Footer() {
+export async function Footer() {
+  "use cache";
+  cacheLife("days");
+
   const statusPageUrl = env.NEXT_PUBLIC_STATUS_PAGE_URL;
 
   return (

--- a/src/components/HeaderAuthButtons.tsx
+++ b/src/components/HeaderAuthButtons.tsx
@@ -6,6 +6,7 @@ import { Button } from "~/components/ui/button";
 import { UserMenu } from "~/components/auth/UserMenu";
 import posthog from "posthog-js";
 import { AnalyticsEvents } from "~/lib/analytics-events";
+import { useSession } from "~/lib/auth-client";
 
 interface HeaderAuthButtonsProps {
   user: { name: string; email: string; image?: string | null } | null;
@@ -13,9 +14,15 @@ interface HeaderAuthButtonsProps {
 
 export function HeaderAuthButtons({ user }: HeaderAuthButtonsProps) {
   const pathname = usePathname();
+  const { data: session, isPending: isSessionLoading } = useSession();
+  const currentUser = session?.user ?? user;
 
-  if (user) {
-    return <UserMenu user={user} />;
+  if (currentUser) {
+    return <UserMenu user={currentUser} />;
+  }
+
+  if (isSessionLoading && !user) {
+    return null;
   }
 
   const showPricing = pathname === "/";

--- a/src/components/HeaderAuthButtons.tsx
+++ b/src/components/HeaderAuthButtons.tsx
@@ -7,6 +7,7 @@ import { UserMenu } from "~/components/auth/UserMenu";
 import posthog from "posthog-js";
 import { AnalyticsEvents } from "~/lib/analytics-events";
 import { useSession } from "~/lib/auth-client";
+import { TRPCReactProvider } from "~/trpc/react";
 
 interface HeaderAuthButtonsProps {
   user: { name: string; email: string; image?: string | null } | null;
@@ -18,7 +19,11 @@ export function HeaderAuthButtons({ user }: HeaderAuthButtonsProps) {
   const currentUser = session?.user ?? user;
 
   if (currentUser) {
-    return <UserMenu user={currentUser} />;
+    return (
+      <TRPCReactProvider>
+        <UserMenu user={currentUser} />
+      </TRPCReactProvider>
+    );
   }
 
   if (isSessionLoading && !user) {

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -1,0 +1,5 @@
+import { HeaderContent } from "~/components/HeaderContent";
+
+export function StaticHeader() {
+  return <HeaderContent user={null} statusData={null} />;
+}

--- a/src/components/home/HomeSearchHero.tsx
+++ b/src/components/home/HomeSearchHero.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Search } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { AnalyticsEvents } from "~/lib/analytics-events";
 
@@ -13,6 +13,10 @@ const SAMPLE_QUERIES = ["Honda Civic", "Toyota Camry", "Ford F-150"];
 export function HomeSearchHero() {
   const router = useRouter();
   const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    router.prefetch("/search");
+  }, [router]);
 
   const submitSearch = (value: string, source: "typed" | "sample") => {
     const trimmed = value.trim();
@@ -47,11 +51,14 @@ export function HomeSearchHero() {
             type="text"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            onFocus={() => router.prefetch("/search")}
             placeholder="Search year, make, or model"
             className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 bg-background h-11 w-full rounded-lg border py-2 pr-11 pl-10 text-base shadow-sm outline-none focus-visible:ring-[3px] sm:h-12 sm:pr-12 sm:pl-11 sm:text-lg"
           />
           <button
             type="submit"
+            onMouseEnter={() => router.prefetch("/search")}
+            onFocus={() => router.prefetch("/search")}
             className="text-muted-foreground hover:text-foreground hover:bg-accent absolute top-1/2 right-1.5 flex size-8 -translate-y-1/2 items-center justify-center rounded-md transition-colors duration-150 ease-out active:scale-[0.95] sm:size-9"
             aria-label="Search"
           >
@@ -65,6 +72,8 @@ export function HomeSearchHero() {
             <button
               key={sample}
               type="button"
+              onMouseEnter={() => router.prefetch("/search")}
+              onFocus={() => router.prefetch("/search")}
               onClick={() => submitSearch(sample, "sample")}
               className="bg-muted hover:bg-muted/80 rounded-md px-3 py-1.5 font-medium transition-colors duration-150 ease-out active:scale-[0.97]"
             >

--- a/src/components/home/HomeSearchHero.tsx
+++ b/src/components/home/HomeSearchHero.tsx
@@ -2,23 +2,22 @@
 
 import { ArrowRight, Search } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { AnalyticsEvents } from "~/lib/analytics-events";
 
 const SAMPLE_QUERIES = ["Honda Civic", "Toyota Camry", "Ford F-150"];
 
 export function HomeSearchHero() {
-  const router = useRouter();
   const [query, setQuery] = useState("");
 
-  useEffect(() => {
-    router.prefetch("/search");
-  }, [router]);
+  const buildSearchHref = (value: string) => {
+    const trimmed = value.trim();
+    return trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : "/search";
+  };
 
-  const submitSearch = (value: string, source: "typed" | "sample") => {
+  const trackSearch = (value: string, source: "typed" | "sample") => {
     const trimmed = value.trim();
     if (!trimmed) return;
 
@@ -28,17 +27,21 @@ export function HomeSearchHero() {
       query_length: trimmed.length,
       submit_source: source,
     });
-
-    router.push(`/search?q=${encodeURIComponent(trimmed)}`);
   };
+
+  const searchHref = buildSearchHref(query);
 
   return (
     <div className="w-full max-w-3xl">
       <form
         onSubmit={(event) => {
-          event.preventDefault();
-          submitSearch(query, "typed");
+          if (!query.trim()) {
+            event.preventDefault();
+            return;
+          }
+          trackSearch(query, "typed");
         }}
+        action="/search"
         className="space-y-3"
       >
         <div className="relative">
@@ -48,37 +51,40 @@ export function HomeSearchHero() {
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3.5 size-4 -translate-y-1/2" />
           <input
             id="home-search"
+            name="q"
             type="text"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            onFocus={() => router.prefetch("/search")}
             placeholder="Search year, make, or model"
             className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 bg-background h-11 w-full rounded-lg border py-2 pr-11 pl-10 text-base shadow-sm outline-none focus-visible:ring-[3px] sm:h-12 sm:pr-12 sm:pl-11 sm:text-lg"
           />
-          <button
-            type="submit"
-            onMouseEnter={() => router.prefetch("/search")}
-            onFocus={() => router.prefetch("/search")}
+          <Link
+            href={searchHref}
+            onClick={(event) => {
+              if (!query.trim()) {
+                event.preventDefault();
+                return;
+              }
+              trackSearch(query, "typed");
+            }}
             className="text-muted-foreground hover:text-foreground hover:bg-accent absolute top-1/2 right-1.5 flex size-8 -translate-y-1/2 items-center justify-center rounded-md transition-colors duration-150 ease-out active:scale-[0.95] sm:size-9"
             aria-label="Search"
           >
             <ArrowRight className="size-4" />
-          </button>
+          </Link>
         </div>
 
         <div className="flex flex-wrap items-center gap-1.5 text-sm sm:gap-2">
           <span className="text-muted-foreground">Try:</span>
           {SAMPLE_QUERIES.map((sample) => (
-            <button
+            <Link
               key={sample}
-              type="button"
-              onMouseEnter={() => router.prefetch("/search")}
-              onFocus={() => router.prefetch("/search")}
-              onClick={() => submitSearch(sample, "sample")}
+              href={buildSearchHref(sample)}
+              onClick={() => trackSearch(sample, "sample")}
               className="bg-muted hover:bg-muted/80 rounded-md px-3 py-1.5 font-medium transition-colors duration-150 ease-out active:scale-[0.97]"
             >
               {sample}
-            </button>
+            </Link>
           ))}
         </div>
       </form>

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -61,6 +61,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { useIsMobile } from "~/hooks/use-media-query";
 import { AnalyticsEvents, buildSearchContext } from "~/lib/analytics-events";
 import { searchClient, ALGOLIA_INDEX_NAME } from "~/lib/algolia-search";
+import { useSession } from "~/lib/auth-client";
 import { MONETIZATION_CONFIG } from "~/lib/constants";
 import {
   hasFiniteCoordinates,
@@ -324,6 +325,8 @@ function AlgoliaSearchInner({
   isLoggedIn,
   userLocation: _userLocation,
 }: SearchPageContentProps) {
+  const { data: session, isPending: isSessionLoading } = useSession();
+  const isAuthenticated = isLoggedIn ?? !!session?.user;
   const currentYear = new Date().getFullYear();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -352,9 +355,7 @@ function AlgoliaSearchInner({
   const {
     data: accountLocationPreference,
     isLoading: isAccountLocationPreferenceLoading,
-  } = api.user.getLocationPreference.useQuery(undefined, {
-    retry: false,
-  });
+  } = api.user.getLocationPreference.useQuery(undefined, { retry: false });
   const resolveZipCodeMutation = api.user.resolveZipCode.useMutation();
   const updateLocationPreferenceMutation =
     api.user.updateLocationPreference.useMutation({
@@ -369,7 +370,7 @@ function AlgoliaSearchInner({
   }, []);
 
   // Prefetch saved searches
-  api.savedSearches.list.useQuery(undefined, { enabled: !!isLoggedIn });
+  api.savedSearches.list.useQuery(undefined, { enabled: isAuthenticated });
 
   // Sidebar state
   const [showFilters, setShowFilters] = useState(false);
@@ -379,12 +380,12 @@ function AlgoliaSearchInner({
   const [autoOpenSaveDialog, setAutoOpenSaveDialog] = useState(false);
 
   useEffect(() => {
-    if (saveSearchParam && isLoggedIn) {
+    if (saveSearchParam && isAuthenticated) {
       setAutoOpenSaveDialog(true);
       void setSaveSearchParam(null);
       clearPendingSaveSearch();
     }
-  }, [saveSearchParam, isLoggedIn, setSaveSearchParam]);
+  }, [saveSearchParam, isAuthenticated, setSaveSearchParam]);
 
   // Handle subscription success
   const [subscriptionParam, setSubscriptionParam] =
@@ -766,7 +767,10 @@ function AlgoliaSearchInner({
   const anonymousClearRows = isMobile ? 3 : 1;
 
   const isAnonymousCapped =
-    !isLoggedIn && !isSearching && nbHits > anonymousVisibleLimit;
+    !isAuthenticated &&
+    !isSessionLoading &&
+    !isSearching &&
+    nbHits > anonymousVisibleLimit;
 
   const visibleVehicles = useMemo(
     () =>
@@ -871,7 +875,7 @@ function AlgoliaSearchInner({
           lng: null,
         };
 
-        if (isLoggedIn) {
+        if (isAuthenticated) {
           await updateLocationPreferenceMutation.mutateAsync({ mode: "auto" });
         }
 
@@ -886,7 +890,7 @@ function AlgoliaSearchInner({
         throw new Error("Enter a valid 5-digit ZIP code.");
       }
 
-      if (isLoggedIn) {
+      if (isAuthenticated) {
         const preference = await updateLocationPreferenceMutation.mutateAsync({
           mode: "zip",
           zipCode: normalizedZipCode,
@@ -915,7 +919,7 @@ function AlgoliaSearchInner({
       setLocalLocationPreference(preference);
     },
     [
-      isLoggedIn,
+      isAuthenticated,
       manualZipCode,
       resolveZipCodeMutation,
       updateLocationPreferenceMutation,
@@ -927,7 +931,7 @@ function AlgoliaSearchInner({
       await applyDistancePreference(selectedDistanceMode);
       setShowDistancePreferenceDialog(false);
       toast.success(
-        isLoggedIn
+        isAuthenticated
           ? "Distance location saved. You can update it later from Settings."
           : "Distance location saved for this browser. You can update it later from account settings.",
       );
@@ -945,7 +949,7 @@ function AlgoliaSearchInner({
     }
   }, [
     applyDistancePreference,
-    isLoggedIn,
+    isAuthenticated,
     pendingDistanceSort,
     refineSortBy,
     selectedDistanceMode,
@@ -1222,7 +1226,7 @@ function AlgoliaSearchInner({
                 {/* Filter buttons */}
                 {isMobile ? (
                   <div className="flex items-center gap-1.5">
-                    {isLoggedIn && <SavedSearchesDropdown iconOnly />}
+                    {isAuthenticated && <SavedSearchesDropdown iconOnly />}
                     <Select value={sortBy} onValueChange={handleSortChange}>
                       <SelectTrigger size="sm" className="w-fit">
                         <SortIcon className="text-muted-foreground h-3.5 w-3.5" />
@@ -1239,7 +1243,7 @@ function AlgoliaSearchInner({
                       query={query}
                       filters={currentSaveSearchFilters}
                       disabled={!query}
-                      isLoggedIn={isLoggedIn}
+                      isLoggedIn={isAuthenticated}
                       autoOpen={autoOpenSaveDialog}
                       onAutoOpenHandled={handleAutoOpenHandled}
                       iconOnly
@@ -1272,7 +1276,7 @@ function AlgoliaSearchInner({
                     activeFilterCount={activeFilterCount}
                     showFilters={showFilters}
                     onToggleFilters={handleToggleFilters}
-                    isLoggedIn={isLoggedIn}
+                    isLoggedIn={isAuthenticated}
                     filters={currentSaveSearchFilters}
                     autoOpenSaveDialog={autoOpenSaveDialog}
                     onAutoOpenHandled={handleAutoOpenHandled}
@@ -1322,7 +1326,7 @@ function AlgoliaSearchInner({
                     </button>
                   ))}
                 </div>
-                {isLoggedIn && <SavedSearchesList />}
+                {isAuthenticated && <SavedSearchesList />}
               </div>
 
               <div className="hidden text-center sm:block">
@@ -1336,7 +1340,7 @@ function AlgoliaSearchInner({
                   Enter a year, make, model, or any combination to search across
                   all available salvage yard locations.
                 </p>
-                {isLoggedIn && <SavedSearchesList />}
+                {isAuthenticated && <SavedSearchesList />}
               </div>
             </div>
           )}
@@ -1421,12 +1425,12 @@ function AlgoliaSearchInner({
                 )}
 
                 <p className="text-muted-foreground mt-6 text-xs">
-                  {isLoggedIn ? (
+                  {isAuthenticated ? (
                     <SaveSearchDialog
                       query={query}
                       filters={currentSaveSearchFilters}
                       disabled={!query}
-                      isLoggedIn={isLoggedIn}
+                      isLoggedIn={isAuthenticated}
                     />
                   ) : (
                     <Link
@@ -1460,7 +1464,7 @@ function AlgoliaSearchInner({
                         query,
                         result_count: 0,
                         visible_result_count: 0,
-                        is_logged_in: isLoggedIn,
+                        is_logged_in: isAuthenticated,
                       })
                     }
                   >

--- a/src/components/search/SearchPageContent.tsx
+++ b/src/components/search/SearchPageContent.tsx
@@ -13,8 +13,10 @@ import { usePathname, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import historyRouter from "instantsearch.js/es/lib/routers/history";
 import {
   Configure,
+  InstantSearch,
   useClearRefinements,
   useInfiniteHits,
   useInstantSearch,
@@ -23,7 +25,6 @@ import {
   useSortBy,
   useStats,
 } from "react-instantsearch";
-import { InstantSearchNext } from "react-instantsearch-nextjs";
 import { useQueryState } from "nuqs";
 import { ErrorBoundary } from "~/components/ErrorBoundary";
 import { MobileFiltersDrawer } from "~/components/search/MobileFiltersDrawer";
@@ -1497,8 +1498,9 @@ function AlgoliaSearchInner({
  */
 function createRouting(indexName: string) {
   return {
-    router: {
+    router: historyRouter({
       cleanUrlOnDispose: false,
+      writeDelay: 400,
       createURL({
         routeState,
         location,
@@ -1571,7 +1573,7 @@ function createRouting(indexName: string) {
 
         return { [indexName]: state };
       },
-    },
+    }),
     stateMapping: {
       stateToRoute(uiState: Record<string, Record<string, unknown>>) {
         const indexState = uiState[indexName] ?? {};
@@ -1665,7 +1667,7 @@ export function SearchPageContent({
   const routing = useMemo(() => createRouting(ALGOLIA_INDEX_NAME), []);
 
   return (
-    <InstantSearchNext
+    <InstantSearch
       searchClient={searchClient}
       indexName={ALGOLIA_INDEX_NAME}
       routing={routing}
@@ -1677,6 +1679,6 @@ export function SearchPageContent({
           userLocation={userLocation}
         />
       </ErrorBoundary>
-    </InstantSearchNext>
+    </InstantSearch>
   );
 }

--- a/src/components/search/SearchPageWithProviders.tsx
+++ b/src/components/search/SearchPageWithProviders.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { SearchPageContent } from "~/components/search/SearchPageContent";
+import { TRPCReactProvider } from "~/trpc/react";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+
+interface SearchPageWithProvidersProps {
+  isLoggedIn?: boolean;
+  userLocation?: { lat: number; lng: number };
+}
+
+export function SearchPageWithProviders(props: SearchPageWithProvidersProps) {
+  return (
+    <NuqsAdapter>
+      <TRPCReactProvider>
+        <SearchPageContent {...props} />
+      </TRPCReactProvider>
+    </NuqsAdapter>
+  );
+}

--- a/src/components/settings/SettingsDashboardWithProviders.tsx
+++ b/src/components/settings/SettingsDashboardWithProviders.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { SettingsDashboard } from "~/components/settings/SettingsDashboard";
+import { TRPCReactProvider } from "~/trpc/react";
+
+export function SettingsDashboardWithProviders() {
+  return (
+    <TRPCReactProvider>
+      <SettingsDashboard />
+    </TRPCReactProvider>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Enable Next 16 `cacheComponents` so Cache Components/PPR can prerender route shells.
- Make `/search` fully static in the production build by removing blocking server request work and using client-side Algolia/tRPC providers only in the search island.
- Convert homepage search submit paths to declarative `/search` links/form behavior instead of imperative router pushes.
- Add route-level Suspense/cache boundaries for dynamic homepage stats, contact personalization, auth params, settings, and unsubscribe state.

### Testing
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- `bun run lint`
- `SKIP_ENV_VALIDATION=1 bun run build` confirms `/search` is `○ (Static)` and dynamic routes use `◐ (Partial Prerender)`.
- Manual browser test: homepage hero search submit transitions to `/search?q=Honda+Civic` with results visible immediately.

### Walkthrough
[ppr_home_search_first_submit.mp4](https://cursor.com/agents/bc-cde986bf-9d73-4c21-bfad-2027b3c303c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fppr_home_search_first_submit.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cde986bf-9d73-4c21-bfad-2027b3c303c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cde986bf-9d73-4c21-bfad-2027b3c303c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warmer search navigation: the app prefetches the search page on mount and on key interactions for faster transitions.

* **Bug Fixes**
  * Improved authentication detection across search and header areas.
  * Fixed loading-state handling during session initialization.
  * Auth-dependent UI and saved-search behavior now respect actual login status.
  * Corrected anonymous-results capping to avoid premature limits while session is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make homepage search navigation instant using static headers and client-side session loading
> - Replaces `Header` with a new `StaticHeader` across multiple pages (home, search, pricing, privacy, contact, settings) so pages render without waiting for session or status data
> - Moves session/auth resolution to the client in `HeaderAuthButtons`, which now reads from `useSession` and renders nothing while the session is loading
> - Rewrites `HomeSearchHero` to navigate via native form `action="/search"` and `Link` elements instead of imperative router calls, making search submission feel instant
> - Replaces `InstantSearchNext` with `InstantSearch` in `SearchPageContent` and switches to a `historyRouter` with a 400ms write delay; session-gated features (saved searches, result caps) now wait for session resolution
> - Moves `NuqsAdapter` and `TRPCReactProvider` out of `RootLayout` and into dedicated client wrappers (`SearchPageWithProviders`, `SettingsDashboardWithProviders`) per page
> - Behavioral Change: `isLoggedIn` and geolocation are no longer resolved server-side on the search page; anonymous result capping is delayed until the client session loads
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdca4a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->