### PR TITLE
Refactor app for cache components

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import("next").NextConfig} */
 const config = {
+  cacheComponents: true,
   images: {
     loader: "custom",
     loaderFile: "./src/lib/wsrvLoader.ts",

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function RootLoading() {
+  return null;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,15 @@
 import { ArrowRight, Bell, Car, Search } from "lucide-react";
 import { type Metadata } from "next";
 import Link from "next/link";
+import { Suspense } from "react";
 import { Footer } from "~/components/Footer";
 import { Header } from "~/components/Header";
+import { HomeLiveStats, HomeLiveStatsSkeleton } from "~/components/home/HomeLiveStats";
 import { HomeSearchHero } from "~/components/home/HomeSearchHero";
 import { TrackedPricingButton } from "~/components/marketing/TrackedPricingButton";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { MONETIZATION_CONFIG } from "~/lib/constants";
-import { api } from "~/trpc/server";
 
 export const metadata: Metadata = {
   title: "Search Salvage Yard Inventory Nationwide",
@@ -19,19 +20,7 @@ export const metadata: Metadata = {
   },
 };
 
-const numberFormatter = new Intl.NumberFormat("en-US");
-
-function formatVehicleCount(count: number): string {
-  return numberFormatter.format(count);
-}
-
-function formatYardCount(count: number): string {
-  return numberFormatter.format(count);
-}
-
 export default async function Home() {
-  const liveStats = await api.stats.live();
-
   return (
     <div className="bg-background flex min-h-dvh flex-col">
       <Header />
@@ -60,39 +49,14 @@ export default async function Home() {
                 <HomeSearchHero />
               </div>
 
-              {/* Mobile proof stats — compact inline row */}
-              <div className="text-muted-foreground mt-5 flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums sm:hidden">
-                <p>
-                  <span className="text-foreground font-medium">
-                    {formatVehicleCount(liveStats.vehicleCount)}
-                  </span>{" "}
-                  vehicles
-                </p>
-                <p>
-                  <span className="text-foreground font-medium">
-                    {formatYardCount(liveStats.yardCount)}
-                  </span>{" "}
-                  yards
-                </p>
-                <p>Free to search</p>
-              </div>
+              <Suspense fallback={<HomeLiveStatsSkeleton variant="mobile" />}>
+                <HomeLiveStats variant="mobile" />
+              </Suspense>
             </div>
 
-            {/* Desktop/tablet proof cards */}
-            <div className="hidden gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-1">
-              <ProofCard
-                title={`${formatVehicleCount(liveStats.vehicleCount)} vehicles tracked`}
-                description="Inventory from multiple salvage networks, updated into one searchable index."
-              />
-              <ProofCard
-                title={`${formatYardCount(liveStats.yardCount)} yards nationwide`}
-                description="Find donor vehicles near you or widen the search when the local yards come up empty."
-              />
-              <ProofCard
-                title="Free search, paid tracking"
-                description="Search anonymously, create a free account to save work, and use Alerts Plan when timing matters."
-              />
-            </div>
+            <Suspense fallback={<HomeLiveStatsSkeleton variant="desktop" />}>
+              <HomeLiveStats variant="desktop" />
+            </Suspense>
           </div>
         </section>
 
@@ -204,25 +168,6 @@ export default async function Home() {
       </main>
 
       <Footer />
-    </div>
-  );
-}
-
-function ProofCard({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="rounded-lg border p-5">
-      <p className="text-lg font-semibold tracking-tight tabular-nums">
-        {title}
-      </p>
-      <p className="text-muted-foreground mt-1.5 text-sm text-pretty">
-        {description}
-      </p>
     </div>
   );
 }

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,0 +1,20 @@
+import { Footer } from "~/components/Footer";
+import { Header } from "~/components/Header";
+import { ScrollToTop } from "~/components/ScrollToTop";
+import { SearchPageShell } from "~/components/search/SearchPageShell";
+import { SearchVisibilityProvider } from "~/context/SearchVisibilityContext";
+
+export default function SearchLoading() {
+  return (
+    <SearchVisibilityProvider>
+      <div className="bg-background flex min-h-svh flex-col">
+        <Header />
+        <div className="flex-1">
+          <SearchPageShell />
+        </div>
+        <Footer />
+        <ScrollToTop />
+      </div>
+    </SearchVisibilityProvider>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,14 +1,12 @@
-import { geolocation } from "@vercel/functions";
 import { type Metadata } from "next";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import { ErrorBoundary } from "~/components/ErrorBoundary";
 import { Footer } from "~/components/Footer";
 import { Header } from "~/components/Header";
 import { ScrollToTop } from "~/components/ScrollToTop";
-import { SearchPageContent } from "~/components/search/SearchPageContent";
+import { SearchPageBootstrap } from "~/components/search/SearchPageBootstrap";
+import { SearchPageShell } from "~/components/search/SearchPageShell";
 import { SearchVisibilityProvider } from "~/context/SearchVisibilityContext";
-import { auth } from "~/lib/auth";
 
 export const metadata: Metadata = {
   title: "Search Salvage Yard Inventory",
@@ -19,39 +17,15 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function SearchPage() {
-  const reqHeaders = await headers();
-
-  const [session, geo] = await Promise.all([
-    auth.api.getSession({ headers: reqHeaders }),
-    Promise.resolve().then(() => {
-      try {
-        // Vercel edge geolocation — available on Vercel deployments
-        const g = geolocation({ headers: reqHeaders });
-        if (g?.latitude && g?.longitude) {
-          return {
-            lat: parseFloat(g.latitude),
-            lng: parseFloat(g.longitude),
-          };
-        }
-      } catch {
-        // Not on Vercel or geolocation unavailable
-      }
-      return undefined;
-    }),
-  ]);
-
+export default function SearchPage() {
   return (
     <SearchVisibilityProvider>
       <div className="bg-background flex min-h-svh flex-col">
         <Header />
         <div className="flex-1">
           <ErrorBoundary>
-            <Suspense>
-              <SearchPageContent
-                isLoggedIn={!!session?.user}
-                userLocation={geo}
-              />
+            <Suspense fallback={<SearchPageShell />}>
+              <SearchPageBootstrap />
             </Suspense>
           </ErrorBoundary>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { env } from "~/env";
 
+const CURRENT_YEAR = new Date().getUTCFullYear();
+
 export function Footer() {
   const statusPageUrl = env.NEXT_PUBLIC_STATUS_PAGE_URL;
 
@@ -53,7 +55,7 @@ export function Footer() {
           )}
         </div>
         <p className="text-muted-foreground text-xs">
-          &copy; {new Date().getFullYear()} Junkyard Index. All rights reserved.
+          &copy; {CURRENT_YEAR} Junkyard Index. All rights reserved.
         </p>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,36 +1,30 @@
-import { headers } from "next/headers";
-import { auth } from "~/lib/auth";
-import { api } from "~/trpc/server";
+import { Suspense } from "react";
+import { Skeleton } from "~/components/ui/skeleton";
 import { HeaderContent } from "./HeaderContent";
-import type { HeaderStatusData } from "./HeaderStatusIndicator";
+import { HeaderAuthSlot, HeaderStatusSlot } from "./HeaderServerSlots";
 
-export async function Header() {
-  const [session, statusData] = await Promise.all([
-    auth.api.getSession({ headers: await headers() }),
-    api.status.providers().then((data): HeaderStatusData | null => {
-      if (data.aggregateStatus === "operational") return null;
-
-      const affected = data.providers
-        .filter((p) => p.status !== "operational")
-        .map((p) => p.name);
-
-      const message =
-        data.aggregateStatus === "in_progress"
-          ? "Ingestion is currently running."
-          : data.aggregateStatus === "degraded"
-          ? "Some yard data may be incomplete."
-          : "Some yard data is temporarily unavailable.";
-
-      return {
-        aggregateStatus: data.aggregateStatus,
-        message,
-        affected: affected.join(", "),
-        statusPageUrl: data.statusPageUrl,
-      };
-    }),
-  ]);
-
+export function Header() {
   return (
-    <HeaderContent user={session?.user ?? null} statusData={statusData} />
+    <HeaderContent
+      statusSlot={
+        <Suspense fallback={null}>
+          <HeaderStatusSlot />
+        </Suspense>
+      }
+      authSlot={
+        <Suspense fallback={<HeaderAuthSkeleton />}>
+          <HeaderAuthSlot />
+        </Suspense>
+      }
+    />
+  );
+}
+
+function HeaderAuthSkeleton() {
+  return (
+    <div className="flex items-center gap-2">
+      <Skeleton className="hidden h-8 w-16 sm:block" />
+      <Skeleton className="h-8 w-32" />
+    </div>
   );
 }

--- a/src/components/HeaderContent.tsx
+++ b/src/components/HeaderContent.tsx
@@ -4,18 +4,18 @@ import { Search } from "lucide-react";
 import Link from "next/link";
 import { Button } from "~/components/ui/button";
 import { useSearchVisibilityOptional } from "~/context/SearchVisibilityContext";
-import { HeaderAuthButtons } from "./HeaderAuthButtons";
-import {
-  HeaderStatusIndicator,
-  type HeaderStatusData,
-} from "./HeaderStatusIndicator";
 
 interface HeaderContentProps {
-  user: { name: string; email: string; image?: string | null } | null;
-  statusData?: HeaderStatusData | null;
+  authSlot?: React.ReactNode;
+  statusSlot?: React.ReactNode;
+  statusSeparatorSlot?: React.ReactNode;
 }
 
-export function HeaderContent({ user, statusData }: HeaderContentProps) {
+export function HeaderContent({
+  authSlot,
+  statusSlot,
+  statusSeparatorSlot,
+}: HeaderContentProps) {
   const searchCtx = useSearchVisibilityOptional();
   const showMobileSearch = searchCtx?.searchBarOffscreen ?? false;
 
@@ -45,13 +45,9 @@ export function HeaderContent({ user, statusData }: HeaderContentProps) {
                 <Search className="h-4 w-4" />
               </Button>
             )}
-            {statusData && (
-              <>
-                <HeaderStatusIndicator data={statusData} />
-                <div className="bg-border h-5 w-px" aria-hidden="true" />
-              </>
-            )}
-            <HeaderAuthButtons user={user} />
+            {statusSlot}
+            {statusSeparatorSlot}
+            {authSlot}
           </div>
         </div>
       </div>

--- a/src/components/HeaderServerSlots.tsx
+++ b/src/components/HeaderServerSlots.tsx
@@ -1,0 +1,55 @@
+import { headers } from "next/headers";
+import { auth } from "~/lib/auth";
+import { getProviderStatus } from "~/server/api/routers/status";
+import { HeaderAuthButtons } from "./HeaderAuthButtons";
+import {
+  HeaderStatusIndicator,
+  type HeaderStatusData,
+} from "./HeaderStatusIndicator";
+
+function toHeaderStatusData(
+  data: Awaited<ReturnType<typeof getProviderStatus>>,
+): HeaderStatusData | null {
+  if (data.aggregateStatus === "operational") {
+    return null;
+  }
+
+  const affected = data.providers
+    .filter((provider) => provider.status !== "operational")
+    .map((provider) => provider.name);
+
+  const message =
+    data.aggregateStatus === "in_progress"
+      ? "Ingestion is currently running."
+      : data.aggregateStatus === "degraded"
+        ? "Some yard data may be incomplete."
+        : "Some yard data is temporarily unavailable.";
+
+  return {
+    aggregateStatus: data.aggregateStatus,
+    message,
+    affected: affected.join(", "),
+    statusPageUrl: data.statusPageUrl,
+  };
+}
+
+export async function HeaderAuthSlot() {
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  return <HeaderAuthButtons user={session?.user ?? null} />;
+}
+
+export async function HeaderStatusSlot() {
+  const statusData = toHeaderStatusData(await getProviderStatus());
+
+  if (!statusData) {
+    return null;
+  }
+
+  return (
+    <>
+      <HeaderStatusIndicator data={statusData} />
+      <div className="bg-border h-5 w-px" aria-hidden="true" />
+    </>
+  );
+}

--- a/src/components/home/HomeLiveStats.tsx
+++ b/src/components/home/HomeLiveStats.tsx
@@ -1,0 +1,108 @@
+import { getLiveHomepageStats } from "~/lib/homepage-stats";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+interface HomeLiveStatsProps {
+  variant: "mobile" | "desktop";
+}
+
+function formatVehicleCount(count: number): string {
+  return numberFormatter.format(count);
+}
+
+function formatYardCount(count: number): string {
+  return numberFormatter.format(count);
+}
+
+export async function HomeLiveStats({ variant }: HomeLiveStatsProps) {
+  const liveStats = await getLiveHomepageStats();
+
+  if (variant === "mobile") {
+    return (
+      <div className="text-muted-foreground mt-5 flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums sm:hidden">
+        <p>
+          <span className="text-foreground font-medium">
+            {formatVehicleCount(liveStats.vehicleCount)}
+          </span>{" "}
+          vehicles
+        </p>
+        <p>
+          <span className="text-foreground font-medium">
+            {formatYardCount(liveStats.yardCount)}
+          </span>{" "}
+          yards
+        </p>
+        <p>Free to search</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hidden gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-1">
+      <ProofCard
+        title={`${formatVehicleCount(liveStats.vehicleCount)} vehicles tracked`}
+        description="Inventory from multiple salvage networks, updated into one searchable index."
+      />
+      <ProofCard
+        title={`${formatYardCount(liveStats.yardCount)} yards nationwide`}
+        description="Find donor vehicles near you or widen the search when the local yards come up empty."
+      />
+      <ProofCard
+        title="Free search, paid tracking"
+        description="Search anonymously, create a free account to save work, and use Alerts Plan when timing matters."
+      />
+    </div>
+  );
+}
+
+export function HomeLiveStatsSkeleton({ variant }: HomeLiveStatsProps) {
+  if (variant === "mobile") {
+    return (
+      <div className="text-muted-foreground mt-5 flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums sm:hidden">
+        <p>
+          <span className="text-foreground font-medium">Loading</span> vehicles
+        </p>
+        <p>
+          <span className="text-foreground font-medium">Loading</span> yards
+        </p>
+        <p>Free to search</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hidden gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-1">
+      <ProofCard
+        title="Loading inventory stats"
+        description="We are fetching current inventory counts from the index."
+      />
+      <ProofCard
+        title="Loading yard coverage"
+        description="We are fetching the current yard footprint for the network."
+      />
+      <ProofCard
+        title="Free search, paid tracking"
+        description="Search anonymously, create a free account to save work, and use Alerts Plan when timing matters."
+      />
+    </div>
+  );
+}
+
+function ProofCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-lg border p-5">
+      <p className="text-lg font-semibold tracking-tight tabular-nums">
+        {title}
+      </p>
+      <p className="text-muted-foreground mt-1.5 text-sm text-pretty">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/src/components/home/HomeSearchHero.tsx
+++ b/src/components/home/HomeSearchHero.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Search } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { AnalyticsEvents } from "~/lib/analytics-events";
 
@@ -13,6 +13,10 @@ const SAMPLE_QUERIES = ["Honda Civic", "Toyota Camry", "Ford F-150"];
 export function HomeSearchHero() {
   const router = useRouter();
   const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    router.prefetch("/search");
+  }, [router]);
 
   const submitSearch = (value: string, source: "typed" | "sample") => {
     const trimmed = value.trim();

--- a/src/components/search/SearchPageBootstrap.tsx
+++ b/src/components/search/SearchPageBootstrap.tsx
@@ -1,0 +1,30 @@
+import { geolocation } from "@vercel/functions";
+import { headers } from "next/headers";
+import { SearchPageContent } from "~/components/search/SearchPageContent";
+import { auth } from "~/lib/auth";
+
+export async function SearchPageBootstrap() {
+  const reqHeaders = await headers();
+
+  const [session, geo] = await Promise.all([
+    auth.api.getSession({ headers: reqHeaders }),
+    Promise.resolve().then(() => {
+      try {
+        const location = geolocation({ headers: reqHeaders });
+
+        if (location?.latitude && location?.longitude) {
+          return {
+            lat: parseFloat(location.latitude),
+            lng: parseFloat(location.longitude),
+          };
+        }
+      } catch {
+        // Geolocation is only available on supported deployments.
+      }
+
+      return undefined;
+    }),
+  ]);
+
+  return <SearchPageContent isLoggedIn={!!session?.user} userLocation={geo} />;
+}

--- a/src/components/search/SearchPageShell.tsx
+++ b/src/components/search/SearchPageShell.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+export function SearchPageShell() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
+      <div className="mb-4">
+        <Skeleton className="h-10 w-full rounded-xl" />
+      </div>
+
+      <div className="relative flex w-full gap-4 md:gap-6">
+        <div className="sticky top-24 hidden h-fit w-64 shrink-0 lg:block lg:w-80">
+          <div className="rounded-xl border p-4">
+            <Skeleton className="h-6 w-24" />
+            <div className="mt-4 space-y-3">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="mb-4 flex flex-wrap gap-2">
+            <Skeleton className="h-10 w-36" />
+            <Skeleton className="h-10 w-28" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="rounded-xl border p-4">
+                <Skeleton className="aspect-[4/3] w-full rounded-lg" />
+                <Skeleton className="mt-4 h-5 w-2/3" />
+                <Skeleton className="mt-2 h-4 w-full" />
+                <Skeleton className="mt-2 h-4 w-5/6" />
+                <Skeleton className="mt-4 h-9 w-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/homepage-stats.ts
+++ b/src/lib/homepage-stats.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { unstable_cache } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { db } from "~/lib/db";
 import { vehicle } from "~/schema";
 
@@ -24,11 +24,11 @@ async function getLiveHomepageStatsInternal(): Promise<HomepageLiveStats> {
   };
 }
 
-export const getLiveHomepageStats = unstable_cache(
-  getLiveHomepageStatsInternal,
-  ["homepage-live-stats"],
-  {
-    revalidate: 3600,
-    tags: ["homepage-live-stats"],
-  },
-);
+export async function getLiveHomepageStats(): Promise<HomepageLiveStats> {
+  "use cache";
+
+  cacheTag("homepage-live-stats");
+  cacheLife("hours");
+
+  return getLiveHomepageStatsInternal();
+}

--- a/src/server/api/routers/status.ts
+++ b/src/server/api/routers/status.ts
@@ -1,5 +1,5 @@
-import { eq, desc } from "drizzle-orm";
-import { unstable_cache } from "next/cache";
+import { desc, eq } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
 import { env } from "~/env";
 import { db } from "~/lib/db";
 import { ingestionSourceRun } from "~/schema";
@@ -91,11 +91,18 @@ async function getProviderStatusInternal(): Promise<StatusResponse> {
   };
 }
 
-const getProviderStatus = unstable_cache(
-  getProviderStatusInternal,
-  ["provider-status"],
-  { revalidate: 10 },
-);
+export async function getProviderStatus(): Promise<StatusResponse> {
+  "use cache";
+
+  cacheTag("provider-status");
+  cacheLife({
+    stale: 10,
+    revalidate: 10,
+    expire: 60,
+  });
+
+  return getProviderStatusInternal();
+}
 
 export const statusRouter = createTRPCRouter({
   providers: publicProcedure.query(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable Next.js cache components in config and add the App Router loading workaround for `next-themes`
- migrate homepage stats and provider status reads from `unstable_cache` to `use cache` helpers
- split the shared header, homepage stats, and search bootstrap into streamed Suspense boundaries so route shells render immediately
- add a `/search` loading shell plus homepage prefetching to smooth the main navigation path

## Testing
- `SKIP_ENV_VALIDATION=1 bun run lint`
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- `SKIP_ENV_VALIDATION=1 bun run build`
- manual production walkthrough on `http://localhost:3001`

## Walkthrough
[ppr_navigation_demo_production_final.mp4](https://cursor.com/agents/bc-e1b808a0-6475-4724-a9da-73c69a632567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fppr_navigation_demo_production_final.mp4)

[Homepage on production server](https://cursor.com/agents/bc-e1b808a0-6475-4724-a9da-73c69a632567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fppr_homepage_production.webp)
[Search results on production server](https://cursor.com/agents/bc-e1b808a0-6475-4724-a9da-73c69a632567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fppr_search_results_production.webp)
[Homepage after return navigation](https://cursor.com/agents/bc-e1b808a0-6475-4724-a9da-73c69a632567/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fppr_homepage_return_production.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1b808a0-6475-4724-a9da-73c69a632567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1b808a0-6475-4724-a9da-73c69a632567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor homepage, search, and header to use Suspense streaming with Next.js cache components
> - Enables `cacheComponents: true` in [next.config.js](https://github.com/AugusDogus/junkyard-index/pull/35/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85) and migrates caching in `getLiveHomepageStats` and `getProviderStatus` from `unstable_cache` to the Next Cache API (`use cache`, `cacheTag`, `cacheLife`).
> - Splits the `Header` into a non-async shell with two async server slot components ([HeaderServerSlots.tsx](https://github.com/AugusDogus/junkyard-index/pull/35/files#diff-272175ae1763b78298954ea0330a962df577b3b4fee8b97182f33e1ddee909e6)) that stream auth status and provider status independently.
> - Replaces blocking server-side stat fetching on the homepage with a Suspense-wrapped `HomeLiveStats` server component and skeleton fallback ([HomeLiveStats.tsx](https://github.com/AugusDogus/junkyard-index/pull/35/files#diff-9382809cb5e228add2d340bb44aa9206eb58a4052a79410b693231d2aeef8f8e)).
> - Converts the search page to a non-async component with a `SearchPageBootstrap` server component ([SearchPageBootstrap.tsx](https://github.com/AugusDogus/junkyard-index/pull/35/files#diff-7f81cb038fb726bcd7e41f36483af898227e71a252307ae0e27ca9033eeb67f7)) that handles session and geolocation within a Suspense boundary.
> - Behavioral Change: pages and the header no longer block on data fetching before first paint; skeleton UIs are shown immediately and content streams in when ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0170cf. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->