### PR TITLE
Mobile landing hero fills the viewport with more breathing room

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,43 +38,48 @@ export default async function Home() {
 
       <main className="flex-1">
         {/* Hero */}
-        <section className="px-4 py-10 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
-          <div className="mx-auto grid max-w-6xl gap-8 sm:gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
-            <div>
-              <Badge variant="outline" className="mb-4 gap-2 px-3 py-1 sm:mb-5">
+        <section className="flex min-h-[calc(100dvh-4rem)] flex-col px-5 pt-8 pb-10 sm:min-h-0 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+          <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 sm:grid sm:max-w-6xl sm:flex-none sm:gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+            <div className="flex flex-1 flex-col sm:block">
+              <Badge variant="outline" className="mb-5 gap-2 self-start px-3 py-1 sm:mb-5">
                 <span className="inline-flex size-2 rounded-full bg-green-500" />
                 Search is free. Alerts are $
                 {MONETIZATION_CONFIG.ALERTS_PLAN_PRICE_MONTHLY}/mo.
               </Badge>
-              <h1 className="max-w-3xl text-3xl font-bold tracking-tight text-balance sm:text-4xl md:text-5xl lg:text-6xl">
+              <h1 className="max-w-3xl text-[2rem] leading-[1.1] font-bold tracking-tight text-balance sm:text-4xl md:text-5xl lg:text-6xl">
                 Search salvage yard inventory before the right donor vehicle is
                 gone.
               </h1>
-              <p className="text-muted-foreground mt-4 max-w-2xl text-base text-pretty sm:mt-5 sm:text-lg md:text-xl">
+              <p className="text-muted-foreground mt-5 max-w-2xl text-base text-pretty sm:mt-5 sm:text-lg md:text-xl">
                 Search across major yard networks in one place. See full results
                 with a free account, then upgrade to alerts when you want new
                 matches delivered automatically.
               </p>
 
-              <div className="mt-6 sm:mt-8">
+              <div className="mt-8 sm:mt-8">
                 <HomeSearchHero />
               </div>
 
-              {/* Mobile proof stats — compact inline row */}
-              <div className="text-muted-foreground mt-5 flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums sm:hidden">
-                <p>
-                  <span className="text-foreground font-medium">
+              {/* Mobile proof stats — full-width breathable row anchored to bottom */}
+              <div className="text-muted-foreground mt-auto grid grid-cols-3 divide-x border-t pt-6 text-sm tabular-nums sm:hidden">
+                <div className="flex flex-col items-start pr-3">
+                  <span className="text-foreground text-lg font-semibold">
                     {formatVehicleCount(liveStats.vehicleCount)}
-                  </span>{" "}
-                  vehicles
-                </p>
-                <p>
-                  <span className="text-foreground font-medium">
+                  </span>
+                  <span className="mt-0.5 text-xs">vehicles</span>
+                </div>
+                <div className="flex flex-col items-start px-3">
+                  <span className="text-foreground text-lg font-semibold">
                     {formatYardCount(liveStats.yardCount)}
-                  </span>{" "}
-                  yards
-                </p>
-                <p>Free to search</p>
+                  </span>
+                  <span className="mt-0.5 text-xs">yards</span>
+                </div>
+                <div className="flex flex-col items-start pl-3">
+                  <span className="text-foreground text-lg font-semibold">
+                    Free
+                  </span>
+                  <span className="mt-0.5 text-xs">to search</span>
+                </div>
               </div>
             </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,47 +38,78 @@ export default async function Home() {
 
       <main className="flex-1">
         {/* Hero */}
-        <section className="flex min-h-[calc(100dvh-4rem)] flex-col px-5 pt-8 pb-10 sm:min-h-0 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
-          <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 sm:grid sm:max-w-6xl sm:flex-none sm:gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
-            <div className="flex flex-1 flex-col sm:block">
-              <Badge variant="outline" className="mb-5 gap-2 self-start px-3 py-1 sm:mb-5">
-                <span className="inline-flex size-2 rounded-full bg-green-500" />
-                Search is free. Alerts are $
-                {MONETIZATION_CONFIG.ALERTS_PLAN_PRICE_MONTHLY}/mo.
-              </Badge>
-              <h1 className="max-w-3xl text-[2rem] leading-[1.1] font-bold tracking-tight text-balance sm:text-4xl md:text-5xl lg:text-6xl">
-                Search salvage yard inventory before the right donor vehicle is
-                gone.
-              </h1>
-              <p className="text-muted-foreground mt-5 max-w-2xl text-base text-pretty sm:mt-5 sm:text-lg md:text-xl">
-                Search across major yard networks in one place. See full results
-                with a free account, then upgrade to alerts when you want new
-                matches delivered automatically.
-              </p>
+        <section className="flex min-h-[calc(100dvh-4rem)] flex-col px-5 pt-6 pb-8 sm:min-h-0 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+          <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col sm:grid sm:max-w-6xl sm:flex-none sm:gap-12 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+            {/*
+              Mobile layout: three rhythm zones distributed across the viewport.
+              - Zone A (intro): pinned to top
+              - Zone B (search): visually centered in the breathing space
+              - Zone C (proof stats): pinned to the bottom, visually substantial
+              `justify-between` with three direct children pushes the empty
+              space *between* the zones rather than pooling it at the bottom.
+              On `sm+` this collapses to a normal block stack so the existing
+              desktop grid layout (text on the left, proof cards on the right)
+              is preserved exactly.
+            */}
+            <div className="flex flex-1 flex-col justify-between gap-10 sm:block sm:flex-none">
+              {/* Zone A — intro */}
+              <div>
+                <Badge
+                  variant="outline"
+                  className="mb-6 gap-2 px-3 py-1 sm:mb-5"
+                >
+                  <span className="inline-flex size-2 rounded-full bg-green-500" />
+                  Search is free. Alerts are $
+                  {MONETIZATION_CONFIG.ALERTS_PLAN_PRICE_MONTHLY}/mo.
+                </Badge>
+                <h1 className="max-w-3xl text-[2rem] leading-[1.1] font-bold tracking-tight text-balance sm:text-4xl md:text-5xl lg:text-6xl">
+                  Search salvage yard inventory before the right donor vehicle
+                  is gone.
+                </h1>
+                <p className="text-muted-foreground mt-5 max-w-2xl text-[1.0625rem] leading-relaxed text-pretty sm:mt-5 sm:text-lg md:text-xl">
+                  Search across major yard networks in one place. See full
+                  results with a free account, then upgrade to alerts when you
+                  want new matches delivered automatically.
+                </p>
+              </div>
 
-              <div className="mt-8 sm:mt-8">
+              {/* Zone B — primary action */}
+              <div className="sm:mt-8">
                 <HomeSearchHero />
               </div>
 
-              {/* Mobile proof stats — full-width breathable row anchored to bottom */}
-              <div className="text-muted-foreground mt-auto grid grid-cols-3 divide-x border-t pt-6 text-sm tabular-nums sm:hidden">
-                <div className="flex flex-col items-start pr-3">
-                  <span className="text-foreground text-lg font-semibold">
-                    {formatVehicleCount(liveStats.vehicleCount)}
-                  </span>
-                  <span className="mt-0.5 text-xs">vehicles</span>
-                </div>
-                <div className="flex flex-col items-start px-3">
-                  <span className="text-foreground text-lg font-semibold">
-                    {formatYardCount(liveStats.yardCount)}
-                  </span>
-                  <span className="mt-0.5 text-xs">yards</span>
-                </div>
-                <div className="flex flex-col items-start pl-3">
-                  <span className="text-foreground text-lg font-semibold">
-                    Free
-                  </span>
-                  <span className="mt-0.5 text-xs">to search</span>
+              {/* Zone C — proof, mobile only; bottom-anchored visual weight */}
+              <div className="border-t pt-6 sm:hidden">
+                <p className="text-muted-foreground mb-4 text-[0.6875rem] font-medium uppercase tracking-[0.1em]">
+                  Live inventory
+                </p>
+                <div className="flex items-end justify-between gap-4 tabular-nums">
+                  <div className="flex flex-col">
+                    <span className="text-foreground text-[1.75rem] leading-none font-semibold tracking-tight">
+                      {formatVehicleCount(liveStats.vehicleCount)}
+                    </span>
+                    <span className="text-muted-foreground mt-2 text-sm">
+                      vehicles
+                    </span>
+                  </div>
+                  <div className="bg-border h-10 w-px" aria-hidden="true" />
+                  <div className="flex flex-col">
+                    <span className="text-foreground text-[1.75rem] leading-none font-semibold tracking-tight">
+                      {formatYardCount(liveStats.yardCount)}
+                    </span>
+                    <span className="text-muted-foreground mt-2 text-sm">
+                      yards
+                    </span>
+                  </div>
+                  <div className="bg-border h-10 w-px" aria-hidden="true" />
+                  <div className="flex flex-col">
+                    <span className="text-foreground text-[1.75rem] leading-none font-semibold tracking-tight">
+                      Free
+                    </span>
+                    <span className="text-muted-foreground mt-2 text-sm">
+                      to search
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/home/HomeSearchHero.tsx
+++ b/src/components/home/HomeSearchHero.tsx
@@ -35,38 +35,38 @@ export function HomeSearchHero() {
           event.preventDefault();
           submitSearch(query, "typed");
         }}
-        className="space-y-3"
+        className="space-y-4 sm:space-y-3"
       >
         <div className="relative">
           <label htmlFor="home-search" className="sr-only">
             Search salvage yard inventory
           </label>
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3.5 size-4 -translate-y-1/2" />
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-4 size-[1.125rem] -translate-y-1/2 sm:left-3.5 sm:size-4" />
           <input
             id="home-search"
             type="text"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search year, make, or model"
-            className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 bg-background h-11 w-full rounded-lg border py-2 pr-11 pl-10 text-base shadow-sm outline-none focus-visible:ring-[3px] sm:h-12 sm:pr-12 sm:pl-11 sm:text-lg"
+            className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 bg-background h-13 w-full rounded-xl border py-2 pr-12 pl-11 text-base shadow-sm outline-none focus-visible:ring-[3px] sm:h-12 sm:rounded-lg sm:pr-12 sm:pl-11 sm:text-lg"
           />
           <button
             type="submit"
-            className="text-muted-foreground hover:text-foreground hover:bg-accent absolute top-1/2 right-1.5 flex size-8 -translate-y-1/2 items-center justify-center rounded-md transition-colors duration-150 ease-out active:scale-[0.95] sm:size-9"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent absolute top-1/2 right-1.5 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg transition-colors duration-150 ease-out active:scale-[0.95] sm:size-9 sm:rounded-md"
             aria-label="Search"
           >
-            <ArrowRight className="size-4" />
+            <ArrowRight className="size-[1.125rem] sm:size-4" />
           </button>
         </div>
 
-        <div className="flex flex-wrap items-center gap-1.5 text-sm sm:gap-2">
-          <span className="text-muted-foreground">Try:</span>
+        <div className="flex flex-wrap items-center gap-2 text-sm sm:gap-2">
+          <span className="text-muted-foreground mr-0.5">Try:</span>
           {SAMPLE_QUERIES.map((sample) => (
             <button
               key={sample}
               type="button"
               onClick={() => submitSearch(sample, "sample")}
-              className="bg-muted hover:bg-muted/80 rounded-md px-3 py-1.5 font-medium transition-colors duration-150 ease-out active:scale-[0.97]"
+              className="bg-muted hover:bg-muted/80 rounded-md px-3 py-2 font-medium transition-colors duration-150 ease-out active:scale-[0.97] sm:py-1.5"
             >
               {sample}
             </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A friend mentioned the landing page felt crowded on mobile. This makes the top section claim the full mobile viewport with **intentional vertical rhythm** — the elements are *distributed* across the available space, not just pushed to the bottom with `mt-auto`. Desktop/tablet (≥ `sm`) layout is unchanged.

## Design approach (v2)

The first iteration used `mt-auto` on the stats row — it stuck to the bottom but left a big empty band of whitespace above it on iPhone 14 Pro / 11 Pro Max. That wasn't taking advantage of the larger viewports, just leaving dead space.

This version restructures the mobile hero as a flex column with three sibling zones and `justify-between`, so the empty space gets distributed *between* zones rather than pooling at the bottom:

- **Zone A — intro**: badge → headline → paragraph. Pinned to the top.
- **Zone B — primary action**: search input + sample chips. Visually centered in the breathing space.
- **Zone C — proof**: a `LIVE INVENTORY` eyebrow with three large numbers separated by hairline dividers. Pinned to the bottom; carries real visual weight.

This collapses to normal block flow at `sm+` so the existing desktop grid (text left, three proof cards right) is preserved.

## Key fixes vs the first iteration

- **Stats no longer overflow their columns.** The first attempt used a `grid-cols-3 divide-x` with `text-3xl` numbers, and `136,558` bled across into the `133` column. Switched to a flex row with explicit `bg-border h-10 w-px` dividers and `text-[1.75rem]` so each stat reads cleanly.
- **Empty space goes between zones, not under them.** `flex-col justify-between` with three direct children replaces the previous `mt-auto`-on-stats approach, so the iPhone 14 Pro and 11 Pro Max viewports get rhythm, not dead air.
- **Stats earn their position.** Upgraded from a thin "136,558 vehicles • 133 yards • Free to search" line to a proper proof block with eyebrow + large numbers, so the bottom of the viewport feels purposeful instead of like an afterthought.
- **Search hero touch targets.** Larger mobile input height (`h-13`, `rounded-xl`), bigger arrow button (`size-10`), roomier "Try" sample chips. Desktop sizes preserved.

## Walkthrough

iPhone 14 Pro (390 × 844) — three zones distributed, stats fit, no overflow:

[Mobile hero on iPhone 14 Pro](https://cursor.com/agents/bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_hero_v3_iphone14.png)

iPhone 11 Pro Max (414 × 896) — even more breathing room across the larger viewport:

[Mobile hero on iPhone 11 Pro Max](https://cursor.com/agents/bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_hero_v3_max.png)

iPhone SE (375 × 667) — smallest common viewport. Stats fall just below the fold, which is the expected trade-off for a 667px tall screen; no overflow or layout breakage:

[Mobile hero on iPhone SE](https://cursor.com/agents/bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_hero_v3_se.png)

Desktop (1280 × 800) — unchanged; mobile-only zone block is hidden:

[Desktop hero unchanged](https://cursor.com/agents/bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_hero_v3.png)

## Testing

- ✅ `bun run lint` — 0 warnings, 0 errors
- ✅ `SKIP_ENV_VALIDATION=1 bun run typecheck` — clean
- ✅ Manual: rendered `/` at 375×667, 390×844, 414×896, and 1280×800; verified no horizontal scroll, three zones distributed across the mobile viewport with intentional spacing, stats numbers stay within their columns, and desktop layout is unchanged.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11b890a-1c34-4b38-837f-b5a1a9d39eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fill mobile hero viewport with three-zone layout and larger search controls
> - Restructures the home page hero in [page.tsx](https://github.com/AugusDogus/junkyard-index/pull/37/files#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3b) into three vertically distributed mobile zones: intro (top), search (center), and proof stats (bottom-anchored), using `min-h-[calc(100dvh-4rem)]` and flexbox `justify-between`.
> - Replaces the compact inline mobile proof stats row with a sectioned 'Zone C' block featuring a top border, 'Live inventory' label, larger numeric displays, vertical separators, and a two-line 'Free / to search' presentation.
> - Updates [HomeSearchHero.tsx](https://github.com/AugusDogus/junkyard-index/pull/37/files#diff-3dab2884a88515ba1b22abd77ceb27aca841c28ea959311958785acf3d997b14) with larger touch targets: taller input (`h-13`), bigger icons, rounder corners (`rounded-xl`), and a larger submit button (`size-10`) on mobile.
> - Desktop and tablet layouts are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1016d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined mobile hero section layout with improved spacing and content distribution
  * Enhanced search input sizing and spacing across device sizes
  * Updated mobile inventory metrics display with clearer visual organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->