### PR TITLE
Fix status tooltip on /search

### DIFF
--- a/src/components/HeaderStatusIndicator.tsx
+++ b/src/components/HeaderStatusIndicator.tsx
@@ -15,6 +15,7 @@ import {
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/use-media-query";
+import { cn } from "~/lib/utils";
 
 export interface HeaderStatusData {
   aggregateStatus: "operational" | "in_progress" | "degraded" | "down";
@@ -37,13 +38,19 @@ function StatusIcon({
   );
 }
 
-function StatusLink({ url }: { url: string }) {
+function StatusLink({
+  url,
+  className,
+}: {
+  url: string;
+  className?: string;
+}) {
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="mt-1 block underline underline-offset-2"
+      className={cn("mt-1 block underline underline-offset-2", className)}
     >
       View Status Page
     </a>
@@ -95,7 +102,9 @@ export function HeaderStatusIndicator({ data }: { data: HeaderStatusData }) {
                 Affected: {data.affected}.
               </DialogDescription>
             </DialogHeader>
-            {data.statusPageUrl && <StatusLink url={data.statusPageUrl} />}
+            {data.statusPageUrl && (
+              <StatusLink url={data.statusPageUrl} className="text-center" />
+            )}
           </DialogContent>
         </Dialog>
       </>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -46,7 +46,10 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          // z-[70] keeps tooltips above the fixed z-[60] morphing search/filter
+          // bars on /search, which otherwise sit over the tooltip and steal
+          // hover, closing it before links inside can be clicked.
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Raise tooltip content z-index from `z-50` to `z-[70]` so it renders above the fixed `z-[60]` morphing search/filter bars on `/search`
- Prevents the invisible search input from intercepting hover and closing the provider status tooltip before the status page link can be clicked

## Test plan
- [ ] Open `/search` with a non-operational provider status visible in the header
- [ ] Hover the status icon and move the mouse down into the tooltip
- [ ] Confirm the tooltip stays open and the "View Status Page" link is clickable
- [ ] Verify tooltips elsewhere (e.g. saved searches on `/search`, homepage header) still behave normally


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status tooltip z-index on /search to render above overlapping elements
> - Increases `TooltipContent` z-index from `z-50` to `z-[70]` in [tooltip.tsx](https://github.com/AugusDogus/junkyard-index/pull/38/files#diff-a79400767c2d21e11b1356a6bc9bf6b2e9d4c75968139f99e7e3f11276525f68) so the status tooltip is not obscured on the search page.
> - Centers the "View Status Page" link in the mobile dialog by passing `className="text-center"` to `StatusLink` in [HeaderStatusIndicator.tsx](https://github.com/AugusDogus/junkyard-index/pull/38/files#diff-37769b2aafedc9043b6386f1e52387157a1f37c02bb61ff86d3a7d2dfea6f7e3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf6c32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the status-page link in the header on mobile for better alignment and spacing.
  * Adjusted tooltip layering so tooltips stay visible above the search/filter interface and don’t close unexpectedly when hovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->